### PR TITLE
Fix timers rate output

### DIFF
--- a/integ/test_integ.py
+++ b/integ/test_integ.py
@@ -183,6 +183,7 @@ class TestInteg(object):
         assert "timers.val.p95|95.000000" in out
         assert "timers.val.p99|99.000000" in out
         assert "timers.val.rate|4950" in out
+        assert "timers.val.sample_rate|100" in out
 
     def test_meters(self, servers):
         "Tests adding kv pairs"
@@ -205,6 +206,7 @@ class TestInteg(object):
         assert "timers.noobs.p95|95.000000" in out
         assert "timers.noobs.p99|99.000000" in out
         assert "timers.noobs.rate|4950" in out
+        assert "timers.noobs.sample_rate|100" in out
 
     def test_histogram(self, servers):
         "Tests adding keys with histograms"
@@ -346,6 +348,7 @@ class TestIntegUDP(object):
         assert "timers.noobs.p95|95.000000" in out
         assert "timers.noobs.p99|99.000000" in out
         assert "timers.noobs.rate|4950" in out
+        assert "timers.noobs.sample_rate|100" in out
 
     def test_sets(self, servers):
         "Tests adding kv pairs"

--- a/src/conn_handler.c
+++ b/src/conn_handler.c
@@ -140,6 +140,7 @@ static int stream_formatter(FILE *pipe, void *data, metric_type type, char *name
             STREAM("%s%s.p95|%f|%lld\n", prefix, name, timer_query(&t->tm, 0.95));
             STREAM("%s%s.p99|%f|%lld\n", prefix, name, timer_query(&t->tm, 0.99));
             STREAM("%s%s.rate|%f|%lld\n", prefix, name, timer_sum(&t->tm) / GLOBAL_CONFIG->flush_interval);
+            STREAM("%s%s.sample_rate|%f|%lld\n", prefix, name, (double)timer_count(&t->tm) / GLOBAL_CONFIG->flush_interval);
 
             // Stream the histogram values
             if (t->conf) {


### PR DESCRIPTION
Seems that correct value for rate in timers is average amount of measurements per second.

Otherwise, please, explain the purpose of dividing sum of all timings by length of flush interval. I can't think of any use for this statistic.
In extended counters, it makes sense, but not in timers.