### PR TITLE
Integ cleanup

### DIFF
--- a/integ/test_binary.py
+++ b/integ/test_binary.py
@@ -45,7 +45,7 @@ stream_cmd = %s
     open(config_path, "w").write(conf)
 
     # Start the process
-    proc = subprocess.Popen("./statsite -f %s" % config_path, shell=True)
+    proc = subprocess.Popen(['./statsite', '-f', config_path])
     proc.poll()
     assert proc.returncode is None
 

--- a/integ/test_binary.py
+++ b/integ/test_binary.py
@@ -4,6 +4,7 @@ of the ASCII protocol.
 """
 import os
 import os.path
+import shutil
 import socket
 import subprocess
 import sys
@@ -54,7 +55,7 @@ stream_cmd = %s
         try:
             proc.kill()
             proc.wait()
-            #shutil.rmtree(tmpdir)
+            shutil.rmtree(tmpdir)
         except:
             print proc
             pass

--- a/integ/test_binary_stream.py
+++ b/integ/test_binary_stream.py
@@ -79,7 +79,7 @@ width=10
     open(config_path, "w").write(conf)
 
     # Start the process
-    proc = subprocess.Popen("./statsite -f %s" % config_path, shell=True)
+    proc = subprocess.Popen(['./statsite', '-f', config_path])
     proc.poll()
     assert proc.returncode is None
 
@@ -149,7 +149,7 @@ width=10
     open(config_path, "w").write(conf)
 
     # Start the process
-    proc = subprocess.Popen("./statsite -f %s" % config_path, shell=True)
+    proc = subprocess.Popen(['./statsite', '-f', config_path])
     proc.poll()
     assert proc.returncode is None
 

--- a/integ/test_binary_stream.py
+++ b/integ/test_binary_stream.py
@@ -5,6 +5,7 @@ protocol.
 """
 import os
 import os.path
+import shutil
 import socket
 import subprocess
 import sys
@@ -88,7 +89,7 @@ width=10
         try:
             proc.kill()
             proc.wait()
-            #shutil.rmtree(tmpdir)
+            shutil.rmtree(tmpdir)
         except:
             print proc
             pass
@@ -158,7 +159,7 @@ width=10
         try:
             proc.kill()
             proc.wait()
-            #shutil.rmtree(tmpdir)
+            shutil.rmtree(tmpdir)
         except:
             print proc
             pass

--- a/integ/test_extended_counters.py
+++ b/integ/test_extended_counters.py
@@ -37,7 +37,7 @@ extended_counters = true
     open(config_path, "w").write(conf)
 
     # Start the process
-    proc = subprocess.Popen("./statsite -f %s" % config_path, shell=True)
+    proc = subprocess.Popen(['./statsite', '-f', config_path])
     proc.poll()
     assert proc.returncode is None
 

--- a/integ/test_extended_counters.py
+++ b/integ/test_extended_counters.py
@@ -1,5 +1,6 @@
 import os
 import os.path
+import shutil
 import socket
 import subprocess
 import sys
@@ -46,7 +47,7 @@ extended_counters = true
         try:
             proc.kill()
             proc.wait()
-            #shutil.rmtree(tmpdir)
+            shutil.rmtree(tmpdir)
         except:
             print proc
             pass

--- a/integ/test_integ.py
+++ b/integ/test_integ.py
@@ -2,6 +2,7 @@ import os
 import os.path
 import socket
 import textwrap
+import shutil
 import subprocess
 import contextlib
 import sys
@@ -54,7 +55,7 @@ width=10
         try:
             proc.kill()
             proc.wait()
-            #shutil.rmtree(tmpdir)
+            shutil.rmtree(tmpdir)
         except:
             print proc
             pass

--- a/integ/test_integ.py
+++ b/integ/test_integ.py
@@ -45,7 +45,7 @@ width=10
     open(config_path, "w").write(conf)
 
     # Start the process
-    proc = subprocess.Popen("./statsite -f %s" % config_path, shell=True)
+    proc = subprocess.Popen(['./statsite', '-f', config_path])
     proc.poll()
     assert proc.returncode is None
 
@@ -382,7 +382,7 @@ class TestIntegBindAddress(object):
         fh.flush()
 
         try:
-            p = subprocess.Popen('./statsite -f %s' % fh.name, shell=True)
+            p = subprocess.Popen(['./statsite', '-f', fh.name])
             time.sleep(0.3)
             yield port
         finally:
@@ -391,8 +391,8 @@ class TestIntegBindAddress(object):
 
     def islistening(self, addr, port, command='statsite'):
         try:
-            cmd = 'lsof -FnPc -nP -i @%s:%s' % (addr, port)
-            out = subprocess.check_output(cmd, shell=True)
+            cmd = ['lsof', '-FnPc', '-nP', '-i', '@%s:%s' % (addr, port)]
+            out = subprocess.check_output(cmd)
         except subprocess.CalledProcessError:
             return False
 

--- a/integ/test_stdin.py
+++ b/integ/test_stdin.py
@@ -44,7 +44,7 @@ width=10
     open(config_path, "w").write(conf)
 
     # Start the process
-    proc = subprocess.Popen("./statsite -f %s" % config_path, shell=True, stdin=subprocess.PIPE)
+    proc = subprocess.Popen(['./statsite', '-f', config_path], stdin=subprocess.PIPE)
     proc.poll()
     assert proc.returncode is None
 

--- a/integ/test_stdin.py
+++ b/integ/test_stdin.py
@@ -2,6 +2,7 @@ import os
 import os.path
 import socket
 import textwrap
+import shutil
 import subprocess
 import contextlib
 import sys
@@ -53,7 +54,7 @@ width=10
         try:
             proc.kill()
             proc.wait()
-            #shutil.rmtree(tmpdir)
+            shutil.rmtree(tmpdir)
         except:
             print proc
             pass


### PR DESCRIPTION
noticed statsite left running upon `make integ` and files left in `/tmp`, fix by not using a shell and exec statsite instead