### PR TITLE
Fix docstring in graphite.py

### DIFF
--- a/sinks/graphite.py
+++ b/sinks/graphite.py
@@ -39,7 +39,7 @@ class GraphiteStore(object):
         Flushes the metrics provided to Graphite.
 
        :Parameters:
-        - `metrics` : A list of (key,value,timestamp) tuples.
+        - `metrics` : A list of "key|value|timestamp" strings.
         """
         if not metrics:
             return


### PR DESCRIPTION
The docstring for the flush method says
     `metrics` : A list of (key,value,timestamp) tuples
while the code expects each metric to be a string with format key|value|timestamp