### PR TITLE
Fix timer count

### DIFF
--- a/src/conn_handler.c
+++ b/src/conn_handler.c
@@ -396,7 +396,9 @@ static int handle_ascii_client_connect(statsite_conn_handler *handle) {
     char *buf, *key, *val_str, *type_str, *sample_str, *endptr;
     metric_type type;
     int buf_len, should_free, status, i, after_len;
-    double val, sample_rate;
+    double val;
+    double sample_rate = 1.0;
+
     while (1) {
         status = extract_to_terminator(handle->conn, '\n', &buf, &buf_len, &should_free);
         if (status == -1) return 0; // Return if no command is available
@@ -445,7 +447,7 @@ static int handle_ascii_client_connect(statsite_conn_handler *handle) {
 
         // Increment the number of inputs received
         if (GLOBAL_CONFIG->input_counter)
-            metrics_add_sample(GLOBAL_METRICS, COUNTER, GLOBAL_CONFIG->input_counter, 1);
+            metrics_add_sample(GLOBAL_METRICS, COUNTER, GLOBAL_CONFIG->input_counter, 1, sample_rate);
 
         // Fast track the set-updates
         if (type == SET) {
@@ -460,21 +462,23 @@ static int handle_ascii_client_connect(statsite_conn_handler *handle) {
             goto ERR_RET;
         }
 
-        // Handle counter sampling if applicable
-        if (type == COUNTER && !buffer_after_terminator(type_str, after_len, '@', &sample_str, &after_len)) {
+        // Handle counter/timer sampling if applicable
+        if ((type == COUNTER || type == TIMER) && !buffer_after_terminator(type_str, after_len, '@', &sample_str, &after_len)) {
             sample_rate = str2double(sample_str, &endptr);
-            if (unlikely(endptr == sample_str)) {
-                syslog(LOG_WARNING, "Failed sample rate conversion! Input: %s", sample_str);
-                goto ERR_RET;
-            }
-            if (sample_rate > 0 && sample_rate <= 1) {
+            if (type == COUNTER) {
+                if (unlikely(endptr == sample_str)) {
+                    syslog(LOG_WARNING, "Failed sample rate conversion! Input: %s", sample_str);
+                    goto ERR_RET;
+                }
+                if (sample_rate > 0 && sample_rate <= 1) {
                 // Magnify the value
                 val = val * (1.0 / sample_rate);
             }
+          }
         }
 
         // Store the sample
-        metrics_add_sample(GLOBAL_METRICS, type, buf, val);
+        metrics_add_sample(GLOBAL_METRICS, type, buf, val, sample_rate);
 
 END_LOOP:
         // Make sure to free the command buffer if we need to
@@ -516,7 +520,7 @@ static int handle_binary_set(statsite_conn_handler *handle, uint16_t *header, in
 
     // Increment the input counter
     if (GLOBAL_CONFIG->input_counter)
-        metrics_add_sample(GLOBAL_METRICS, COUNTER, GLOBAL_CONFIG->input_counter, 1);
+        metrics_add_sample(GLOBAL_METRICS, COUNTER, GLOBAL_CONFIG->input_counter, 1, 1.0);
 
     // Update the set
     metrics_set_update(GLOBAL_METRICS, key, key+header[1]);
@@ -606,10 +610,10 @@ static int handle_binary_client_connect(statsite_conn_handler *handle) {
 
         // Increment the input counter
         if (GLOBAL_CONFIG->input_counter)
-            metrics_add_sample(GLOBAL_METRICS, COUNTER, GLOBAL_CONFIG->input_counter, 1);
+            metrics_add_sample(GLOBAL_METRICS, COUNTER, GLOBAL_CONFIG->input_counter, 1, 1.0);
 
         // Add the sample
-        metrics_add_sample(GLOBAL_METRICS, type, (char*)key, *(double*)(cmd+4));
+        metrics_add_sample(GLOBAL_METRICS, type, (char*)key, *(double*)(cmd+4), 1.0);
 
         // Make sure to free the command buffer if we need to
         if (unlikely(should_free)) free(cmd);

--- a/src/metrics.c
+++ b/src/metrics.c
@@ -127,7 +127,7 @@ static int metrics_increment_counter(metrics *m, char *name, double val) {
  * @arg val The sample to add
  * @return 0 on success.
  */
-static int metrics_add_timer_sample(metrics *m, char *name, double val) {
+static int metrics_add_timer_sample(metrics *m, char *name, double val, double sample_rate) {
     timer_hist *t;
     histogram_config *conf;
     int res = hashmap_get(m->timers, name, (void**)&t);
@@ -162,7 +162,7 @@ static int metrics_add_timer_sample(metrics *m, char *name, double val) {
     }
 
     // Add the sample value
-    return timer_add_sample(&t->tm, val);
+    return timer_add_sample(&t->tm, val, sample_rate);
 }
 
 /**
@@ -213,7 +213,7 @@ static int metrics_set_gauge(metrics *m, char *name, double val, bool delta) {
  * @arg val The sample to add
  * @return 0 on success.
  */
-int metrics_add_sample(metrics *m, metric_type type, char *name, double val) {
+int metrics_add_sample(metrics *m, metric_type type, char *name, double val, double sample_rate) {
     switch (type) {
         case KEY_VAL:
             return metrics_add_kv(m, name, val);
@@ -228,7 +228,7 @@ int metrics_add_sample(metrics *m, metric_type type, char *name, double val) {
             return metrics_increment_counter(m, name, val);
 
         case TIMER:
-            return metrics_add_timer_sample(m, name, val);
+            return metrics_add_timer_sample(m, name, val, sample_rate);
 
         default:
             return -1;
@@ -336,4 +336,3 @@ static int iter_cb(void *data, const char *key, void *value) {
     struct cb_info *info = data;
     return info->cb(info->data, info->type, (char*)key, value);
 }
-

--- a/src/metrics.c
+++ b/src/metrics.c
@@ -125,6 +125,7 @@ static int metrics_increment_counter(metrics *m, char *name, double val) {
  * given name.
  * @arg name The name of the timer
  * @arg val The sample to add
+ * @arg sample_rate The sample rate of val
  * @return 0 on success.
  */
 static int metrics_add_timer_sample(metrics *m, char *name, double val, double sample_rate) {

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -74,7 +74,7 @@ int destroy_metrics(metrics *m);
  * @arg val The sample to add
  * @return 0 on success.
  */
-int metrics_add_sample(metrics *m, metric_type type, char *name, double val);
+int metrics_add_sample(metrics *m, metric_type type, char *name, double val, double sample_rate);
 
 /**
  * Adds a value to a named set.

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -72,6 +72,7 @@ int destroy_metrics(metrics *m);
  * arg type The type of the metrics
  * @arg name The name of the metric
  * @arg val The sample to add
+ * @arg sample_rate The sample rate of val
  * @return 0 on success.
  */
 int metrics_add_sample(metrics *m, metric_type type, char *name, double val, double sample_rate);

--- a/src/timer.c
+++ b/src/timer.c
@@ -13,6 +13,7 @@ static void finalize_timer(timer *timer);
  * @return 0 on success.
  */
 int init_timer(double eps, double *quantiles, uint32_t num_quants, timer *timer) {
+    timer->actual_count = 0;
     timer->count = 0;
     timer->sum = 0;
     timer->squared_sum = 0;
@@ -34,10 +35,12 @@ int destroy_timer(timer *timer) {
  * Adds a new sample to the struct
  * @arg timer The timer to add to
  * @arg sample The new sample value
+ * @arg sample_rate The sample rate
  * @return 0 on success.
  */
-int timer_add_sample(timer *timer, double sample) {
-    timer->count += 1;
+int timer_add_sample(timer *timer, double sample, double sample_rate) {
+    timer->actual_count += 1;
+    timer->count += (1 / sample_rate);
     timer->sum += sample;
     timer->squared_sum += pow(sample, 2);
     timer->finalized = 0;
@@ -81,7 +84,7 @@ double timer_min(timer *timer) {
  * @return The mean value
  */
 double timer_mean(timer *timer) {
-    return (timer->count) ? timer->sum / timer->count : 0;
+    return (timer->actual_count) ? timer->sum / timer->actual_count : 0;
 }
 
 /**
@@ -90,8 +93,8 @@ double timer_mean(timer *timer) {
  * @return The sample standard deviation
  */
 double timer_stddev(timer *timer) {
-    double num = (timer->count * timer->squared_sum) - pow(timer->sum, 2);
-    double div = timer->count * (timer->count - 1);
+    double num = (timer->actual_count * timer->squared_sum) - pow(timer->sum, 2);
+    double div = timer->actual_count * (timer->actual_count - 1);
     if (div == 0) return 0;
     return sqrt(num / div);
 }
@@ -135,4 +138,3 @@ static void finalize_timer(timer *timer) {
 
     timer->finalized = 1;
 }
-

--- a/src/timer.h
+++ b/src/timer.h
@@ -4,7 +4,8 @@
 #include "cm_quantile.h"
 
 typedef struct {
-    uint64_t count;     // Count of items
+    uint16_t actual_count; // Actual items recieved
+    uint64_t count;     // Count of items (1 / sample rate)
     double sum;         // Sum of the values
     double squared_sum; // Sum of the squared values
     int finalized;      // Is the cm_quantile finalized
@@ -34,7 +35,7 @@ int destroy_timer(timer *timer);
  * @arg sample The new sample value
  * @return 0 on success.
  */
-int timer_add_sample(timer *timer, double sample);
+int timer_add_sample(timer *timer, double sample, double sample_rate);
 
 /**
  * Queries for a quantile value

--- a/src/timer.h
+++ b/src/timer.h
@@ -4,7 +4,7 @@
 #include "cm_quantile.h"
 
 typedef struct {
-    uint16_t actual_count; // Actual items recieved
+    uint64_t actual_count; // Actual items recieved
     uint64_t count;     // Count of items (1 / sample rate)
     double sum;         // Sum of the values
     double squared_sum; // Sum of the squared values

--- a/tests/runner.c
+++ b/tests/runner.c
@@ -76,7 +76,8 @@ int main(void)
     tcase_add_test(tc4, test_timer_init_and_destroy);
     tcase_add_test(tc4, test_timer_init_add_destroy);
     tcase_add_test(tc4, test_timer_add_loop);
-
+    tcase_add_test(tc4, test_timer_sample_rate);
+    
     // Add the counter tests
     suite_add_tcase(s1, tc5);
     tcase_add_test(tc5, test_counter_init);
@@ -121,7 +122,7 @@ int main(void)
     tcase_add_test(tc8, test_sane_prefixes);
     tcase_add_test(tc8, test_sane_global_prefix);
     tcase_add_test(tc8, test_sane_quantiles);
-    
+
     // Add the radix tests
     suite_add_tcase(s1, tc9);
     tcase_add_test(tc9, test_radix_init_and_destroy);
@@ -155,4 +156,3 @@ int main(void)
 
     return nf == 0 ? 0 : 1;
 }
-

--- a/tests/test_metrics.c
+++ b/tests/test_metrics.c
@@ -67,7 +67,7 @@ START_TEST(test_metrics_add_iter)
     fail_unless(res == 0);
 
     int okay = 0;
-    fail_unless(metrics_add_sample(&m, KEY_VAL, "test", 100) == 0);
+    fail_unless(metrics_add_sample(&m, KEY_VAL, "test", 100, 1.0) == 0);
     fail_unless(metrics_iter(&m, (void*)&okay, iter_test_cb) == 0);
     fail_unless(okay == 1);
 
@@ -117,20 +117,20 @@ START_TEST(test_metrics_add_all_iter)
     int res = init_metrics_defaults(&m);
     fail_unless(res == 0);
 
-    fail_unless(metrics_add_sample(&m, KEY_VAL, "test", 100) == 0);
-    fail_unless(metrics_add_sample(&m, KEY_VAL, "test2", 42) == 0);
+    fail_unless(metrics_add_sample(&m, KEY_VAL, "test", 100, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, KEY_VAL, "test2", 42, 1.0) == 0);
 
-    fail_unless(metrics_add_sample(&m, GAUGE, "g1", 1) == 0);
-    fail_unless(metrics_add_sample(&m, GAUGE, "g1", 200) == 0);
-    fail_unless(metrics_add_sample(&m, GAUGE, "g2", 42) == 0);
+    fail_unless(metrics_add_sample(&m, GAUGE, "g1", 1, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, GAUGE, "g1", 200, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, GAUGE, "g2", 42, 1.0) == 0);
 
-    fail_unless(metrics_add_sample(&m, COUNTER, "foo", 4) == 0);
-    fail_unless(metrics_add_sample(&m, COUNTER, "foo", 6) == 0);
-    fail_unless(metrics_add_sample(&m, COUNTER, "bar", 10) == 0);
-    fail_unless(metrics_add_sample(&m, COUNTER, "bar", 20) == 0);
+    fail_unless(metrics_add_sample(&m, COUNTER, "foo", 4, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, COUNTER, "foo", 6, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, COUNTER, "bar", 10, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, COUNTER, "bar", 20, 1.0) == 0);
 
-    fail_unless(metrics_add_sample(&m, TIMER, "baz", 1) == 0);
-    fail_unless(metrics_add_sample(&m, TIMER, "baz", 10) == 0);
+    fail_unless(metrics_add_sample(&m, TIMER, "baz", 1, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, TIMER, "baz", 10, 1.0) == 0);
 
     fail_unless(metrics_set_update(&m, "zip", "foo") == 0);
     fail_unless(metrics_set_update(&m, "zip", "wow") == 0);
@@ -176,15 +176,15 @@ START_TEST(test_metrics_histogram)
     res = init_metrics(0.01, (double*)&quants, 3, config.histograms, 12, &m);
     fail_unless(res == 0);
 
-    fail_unless(metrics_add_sample(&m, TIMER, "baz", 1) == 0);
-    fail_unless(metrics_add_sample(&m, TIMER, "baz", 10) == 0);
-    fail_unless(metrics_add_sample(&m, TIMER, "baz", -1) == 0);
-    fail_unless(metrics_add_sample(&m, TIMER, "baz", 50) == 0);
+    fail_unless(metrics_add_sample(&m, TIMER, "baz", 1, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, TIMER, "baz", 10, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, TIMER, "baz", -1, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, TIMER, "baz", 50, 1.0) == 0);
 
-    fail_unless(metrics_add_sample(&m, TIMER, "zip", 1) == 0);
-    fail_unless(metrics_add_sample(&m, TIMER, "zip", 10) == 0);
-    fail_unless(metrics_add_sample(&m, TIMER, "zip", -1) == 0);
-    fail_unless(metrics_add_sample(&m, TIMER, "zip", 50) == 0);
+    fail_unless(metrics_add_sample(&m, TIMER, "zip", 1, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, TIMER, "zip", 10, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, TIMER, "zip", -1, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, TIMER, "zip", 50, 1.0) == 0);
 
     int okay = 0;
     fail_unless(metrics_iter(&m, (void*)&okay, iter_test_histogram) == 0);
@@ -214,11 +214,11 @@ START_TEST(test_metrics_gauges)
     int res = init_metrics_defaults(&m);
     fail_unless(res == 0);
 
-    fail_unless(metrics_add_sample(&m, GAUGE, "g1", 1) == 0);
-    fail_unless(metrics_add_sample(&m, GAUGE_DELTA, "g1", 41) == 0);
+    fail_unless(metrics_add_sample(&m, GAUGE, "g1", 1, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, GAUGE_DELTA, "g1", 41, 1.0) == 0);
 
-    fail_unless(metrics_add_sample(&m, GAUGE_DELTA, "g2", 100) == 0);
-    fail_unless(metrics_add_sample(&m, GAUGE_DELTA, "g3", -100) == 0);
+    fail_unless(metrics_add_sample(&m, GAUGE_DELTA, "g2", 100, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, GAUGE_DELTA, "g3", -100, 1.0) == 0);
 
     int okay = 0;
     fail_unless(metrics_iter(&m, (void*)&okay, iter_test_gauge) == 0);
@@ -228,4 +228,3 @@ START_TEST(test_metrics_gauges)
     fail_unless(res == 0);
 }
 END_TEST
-

--- a/tests/test_streaming.c
+++ b/tests/test_streaming.c
@@ -71,14 +71,14 @@ START_TEST(test_stream_some)
     fail_unless(res == 0);
 
     // Add some metrics
-    fail_unless(metrics_add_sample(&m, KEY_VAL, "test", 100) == 0);
-    fail_unless(metrics_add_sample(&m, KEY_VAL, "test2", 42) == 0);
-    fail_unless(metrics_add_sample(&m, COUNTER, "foo", 4) == 0);
-    fail_unless(metrics_add_sample(&m, COUNTER, "foo", 6) == 0);
-    fail_unless(metrics_add_sample(&m, COUNTER, "bar", 10) == 0);
-    fail_unless(metrics_add_sample(&m, COUNTER, "bar", 20) == 0);
-    fail_unless(metrics_add_sample(&m, TIMER, "baz", 1) == 0);
-    fail_unless(metrics_add_sample(&m, TIMER, "baz", 10) == 0);
+    fail_unless(metrics_add_sample(&m, KEY_VAL, "test", 100, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, KEY_VAL, "test2", 42, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, COUNTER, "foo", 4, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, COUNTER, "foo", 6, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, COUNTER, "bar", 10, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, COUNTER, "bar", 20, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, TIMER, "baz", 1, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, TIMER, "baz", 10, 1.0) == 0);
 
     int called = 0;
     res = stream_to_command(&m, &called, some_cb, "cat > /tmp/stream_some");
@@ -111,14 +111,14 @@ START_TEST(test_stream_bad_cmd)
     fail_unless(res == 0);
 
     // Add some metrics
-    fail_unless(metrics_add_sample(&m, KEY_VAL, "test", 100) == 0);
-    fail_unless(metrics_add_sample(&m, KEY_VAL, "test2", 42) == 0);
-    fail_unless(metrics_add_sample(&m, COUNTER, "foo", 4) == 0);
-    fail_unless(metrics_add_sample(&m, COUNTER, "foo", 6) == 0);
-    fail_unless(metrics_add_sample(&m, COUNTER, "bar", 10) == 0);
-    fail_unless(metrics_add_sample(&m, COUNTER, "bar", 20) == 0);
-    fail_unless(metrics_add_sample(&m, TIMER, "baz", 1) == 0);
-    fail_unless(metrics_add_sample(&m, TIMER, "baz", 10) == 0);
+    fail_unless(metrics_add_sample(&m, KEY_VAL, "test", 100, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, KEY_VAL, "test2", 42, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, COUNTER, "foo", 4, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, COUNTER, "foo", 6, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, COUNTER, "bar", 10, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, COUNTER, "bar", 20, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, TIMER, "baz", 1, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, TIMER, "baz", 10, 1.0) == 0);
 
     int called = 0;
     res = stream_to_command(&m, &called, some_cb, "abcd 2>/dev/null");
@@ -136,14 +136,14 @@ START_TEST(test_stream_sigpipe)
     fail_unless(res == 0);
 
     // Add some metrics
-    fail_unless(metrics_add_sample(&m, KEY_VAL, "test", 100) == 0);
-    fail_unless(metrics_add_sample(&m, KEY_VAL, "test2", 42) == 0);
-    fail_unless(metrics_add_sample(&m, COUNTER, "foo", 4) == 0);
-    fail_unless(metrics_add_sample(&m, COUNTER, "foo", 6) == 0);
-    fail_unless(metrics_add_sample(&m, COUNTER, "bar", 10) == 0);
-    fail_unless(metrics_add_sample(&m, COUNTER, "bar", 20) == 0);
-    fail_unless(metrics_add_sample(&m, TIMER, "baz", 1) == 0);
-    fail_unless(metrics_add_sample(&m, TIMER, "baz", 10) == 0);
+    fail_unless(metrics_add_sample(&m, KEY_VAL, "test", 100, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, KEY_VAL, "test2", 42, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, COUNTER, "foo", 4, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, COUNTER, "foo", 6, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, COUNTER, "bar", 10, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, COUNTER, "bar", 20, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, TIMER, "baz", 1, 1.0) == 0);
+    fail_unless(metrics_add_sample(&m, TIMER, "baz", 10, 1.0) == 0);
 
     int called = 0;
     res = stream_to_command(&m, &called, some_cb, "head -n1 >/dev/null");
@@ -153,4 +153,3 @@ START_TEST(test_stream_sigpipe)
     fail_unless(res == 0);
 }
 END_TEST
-

--- a/tests/test_timer.c
+++ b/tests/test_timer.c
@@ -28,7 +28,7 @@ START_TEST(test_timer_init_add_destroy)
     int res = init_timer(0.01, (double*)&quants, 3, &t);
     fail_unless(res == 0);
 
-    fail_unless(timer_add_sample(&t, 100) == 0);
+    fail_unless(timer_add_sample(&t, 100, 1.0) == 0);
     fail_unless(timer_count(&t) == 1);
     fail_unless(timer_sum(&t) == 100);
     fail_unless(timer_squared_sum(&t) == 10000);
@@ -51,7 +51,7 @@ START_TEST(test_timer_add_loop)
     fail_unless(res == 0);
 
     for (int i=1; i<=100; i++)
-        fail_unless(timer_add_sample(&t, i) == 0);
+        fail_unless(timer_add_sample(&t, i, 1.0) == 0);
 
     fail_unless(timer_count(&t) == 100);
     fail_unless(timer_sum(&t) == 5050);
@@ -69,3 +69,28 @@ START_TEST(test_timer_add_loop)
 }
 END_TEST
 
+START_TEST(test_timer_sample_rate)
+{
+  timer t;
+  double quants[] = {0.5, 0.90, 0.99};
+  int res = init_timer(0.01, (double*)&quants, 3, &t);
+  fail_unless(res == 0);
+
+  for (int i=1; i<=100; i++)
+      fail_unless(timer_add_sample(&t, i, 0.5) == 0);
+
+  fail_unless(timer_count(&t) == 200);
+  fail_unless(timer_sum(&t) == 5050);
+  fail_unless(timer_squared_sum(&t) == 338350);
+  fail_unless(timer_min(&t) == 1);
+  fail_unless(timer_max(&t) == 100);
+  fail_unless(timer_mean(&t) == 50.5);
+  fail_unless(round(timer_stddev(&t)*1000)/1000 == 29.011);
+  fail_unless(timer_query(&t, 0.5) == 50);
+  fail_unless(timer_query(&t, 0.90) >= 89 && timer_query(&t, 0.90) <= 91);
+  fail_unless(timer_query(&t, 0.99) >= 98 && timer_query(&t, 0.99) <= 100);
+
+  res = destroy_timer(&t);
+  fail_unless(res == 0);
+}
+END_TEST


### PR DESCRIPTION
fixes #142 

Simple example test using netcat: Executed these in succession
echo "foo:5|ms|@0.5" | nc -u -w0 127.0.0.1
echo "foo:5|ms|@0.5" | nc -u -w0 127.0.0.1
echo "foo:5|ms|@0.5" | nc -u -w0 127.0.0.1
echo "foo:5|ms|@0.5" | nc -u -w0 127.0.0.1

Output from custom sink script:

Before:
'timers.foo.count|4|1439367451’,
'timers.foo.mean|5.000000|1439367451',
'timers.foo.sample_rate|0.400000|1439367451’,

After:
'timers.foo.count|8|1439365840’,
'timers.foo.mean|5.000000|1439365840’,
'timers.foo.sample_rate|0.800000|1439365840’,