### PR TITLE
Extended counters include

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,9 @@ options must exist in the `statsite` section of the INI file:
   `lower`, `upper`, and `rate`.
   Defaults to false.
 
+* extended\_counters\_include : Allows you to configure which extended counters to include 
+  through a comma separated list of values, extended\_counters must be set to true.
+
 * prefix\_binary\_stream : If enabled, the keys streamed to a the stream\_cmd
   when using binary\_stream mode are also prefixed. By default, this is false,
   and keys do not get the prefix.

--- a/README.md
+++ b/README.md
@@ -200,12 +200,13 @@ options must exist in the `statsite` section of the INI file:
 
 * extended\_counters : If enabled, the counter output is extended to include
   all the computed summary values. Otherwise, the counter is emitted as just
-  the sum value. Summary values include `mean`, `stdev`, `sum`, `sum_sq`,
+  the sum value. Summary values include `count`, `mean`, `stdev`, `sum`, `sum_sq`,
   `lower`, `upper`, and `rate`.
   Defaults to false.
 
 * extended\_counters\_include : Allows you to configure which extended counters to include 
-  through a comma separated list of values, extended\_counters must be set to true.
+  through a comma separated list of values, extended\_counters must be set to true. Supported values include `count`, `mean`, `stdev`, `sum`, `sum_sq`,
+  `lower`, `upper`, and `rate`. If this option is not specified but extended_counters is set to true, then all values will be included by default.
 
 * prefix\_binary\_stream : If enabled, the keys streamed to a the stream\_cmd
   when using binary\_stream mode are also prefixed. By default, this is false,

--- a/integ/test_extended_counters_include.py
+++ b/integ/test_extended_counters_include.py
@@ -1,0 +1,111 @@
+import os
+import os.path
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import random
+
+try:
+    import pytest
+except ImportError:
+    print >> sys.stderr, "Integ tests require pytests!"
+    sys.exit(1)
+
+
+def pytest_funcarg__servers(request):
+    "Returns a new APIHandler with a filter manager"
+    # Create tmpdir and delete after
+    tmpdir = tempfile.mkdtemp()
+
+    # Make the command
+    output = "%s/output" % tmpdir
+    cmd = "cat >> %s" % output
+
+    # Write the configuration
+    port = random.randrange(10000, 65000)
+    config_path = os.path.join(tmpdir, "config.cfg")
+    conf = """[statsite]
+flush_interval = 1
+port = %d
+udp_port = %d
+stream_cmd = %s
+extended_counters = true
+extended_counters_include = MEAN,STDEV,SUM,SUM_SQ,LOWER,UPPER
+
+""" % (port, port, cmd)
+    open(config_path, "w").write(conf)
+
+    # Start the process
+    proc = subprocess.Popen(['./statsite', '-f', config_path])
+    proc.poll()
+    assert proc.returncode is None
+
+    # Define a cleanup handler
+    def cleanup():
+        try:
+            proc.kill()
+            proc.wait()
+            shutil.rmtree(tmpdir)
+        except:
+            print proc
+            pass
+    request.addfinalizer(cleanup)
+
+    # Make a connection to the server
+    connected = False
+    for x in xrange(3):
+        try:
+            conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            conn.settimeout(1)
+            conn.connect(("localhost", port))
+            connected = True
+            break
+        except Exception, e:
+            print e
+            time.sleep(0.5)
+
+    # Die now
+    if not connected:
+        raise EnvironmentError("Failed to connect!")
+
+    # Make a second connection
+    conn2 = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    conn2.connect(("localhost", port))
+
+    # Return the connection
+    return conn, conn2, output
+
+
+def wait_file(path, timeout=5):
+    "Waits on a file to be make"
+    start = time.time()
+    while not os.path.isfile(path) and time.time() - start < timeout:
+        time.sleep(0.1)
+    if not os.path.isfile(path):
+        raise Exception("Timed out waiting for file %s" % path)
+    while os.path.getsize(path) == 0 and time.time() - start < timeout:
+        time.sleep(0.1)
+
+
+class TestInteg(object):
+    def test_counters(self, servers):
+        "Tests adding kv pairs"
+        server, _, output = servers
+        server.sendall("foobar:100|c\n")
+        server.sendall("foobar:200|c\n")
+        server.sendall("foobar:300|c\n")
+
+        wait_file(output)
+        out = open(output).read()
+        assert "counts.foobar.count|3" not in out
+        assert "counts.foobar.rate|600" not in out
+        assert "counts.foobar.mean|200" in out
+        assert "counts.foobar.stdev|100" in out
+        assert "counts.foobar.sum|600" in out
+        assert "counts.foobar.sum_sq|140000" in out
+        assert "counts.foobar.lower|100" in out
+        assert "counts.foobar.upper|300" in out
+

--- a/src/config.c
+++ b/src/config.c
@@ -21,6 +21,12 @@ static char* histogram_section;
 static histogram_config *in_progress;
 
 /**
+ * Pointer used for parsing extended config includes option
+ *
+ */ 
+static extended_counters_config *extended_counters_cfg;
+
+/**
  * Default statsite_config values. Should create
  * filters that are about 300KB initially, and suited
  * to grow quickly.
@@ -50,7 +56,8 @@ static const statsite_config DEFAULT_CONFIG = {
     "",                 // Global prefix
     {"", "kv.", "gauges.", "counts.", "timers.", "sets.", ""},
     {},
-    false,              // Extended counts off by default
+    false,              // Extended counters off by default
+    NULL,               // Specify which extended counters to use.
     false,              // Do not prefix binary stream by default
                         // Number of quantiles
     sizeof(default_quantiles) / sizeof(double),
@@ -130,6 +137,49 @@ static int value_to_list_of_doubles(const char *val, double **result, int *count
     sscanf(val, " %n", &scanned);
 
     return val[scanned] == '\0';
+}
+
+
+/**
+* Parsing the extended counters config
+* @arg config The global config
+* @arg value the extended counters to be used
+* 
+*/
+void csv_to_extended_counters_config(statsite_config *config, const char *value)
+{
+
+    *extended_counters_cfg = (extended_counters_config){false, false, false, false, false, false, false, false};
+
+    char* token;
+
+    char s[256];
+    strcpy(s, value);
+    token = strtok(s,",");
+    while( token != NULL )
+    {
+        if (strcasecmp(token, "COUNT") == 0){
+            extended_counters_cfg->count = true;
+        } else if(strcasecmp(token, "MEAN") == 0){
+            extended_counters_cfg->mean = true;
+        } else if (strcasecmp(token, "STDEV") == 0){
+            extended_counters_cfg->stdev = true;
+        } else if (strcasecmp(token, "SUM") == 0){
+            extended_counters_cfg->sum = true;
+        } else if (strcasecmp(token, "SUM_SQ") == 0){
+            extended_counters_cfg->sum_sq = true;
+        } else if (strcasecmp(token, "LOWER") == 0){
+            extended_counters_cfg->lower = true;
+        } else if (strcasecmp(token, "UPPER") == 0){
+            extended_counters_cfg->upper = true;
+        } else if (strcasecmp(token, "RATE") == 0){
+            extended_counters_cfg->rate = true;
+
+        }
+        token = strtok(NULL, ",");
+    }
+
+    config->ext_counters_config = extended_counters_cfg;
 }
 
 /**
@@ -311,13 +361,13 @@ static int config_callback(void* user, const char* section, const char* name, co
         config->prefixes[TIMER] = strdup(value);
     } else if (NAME_MATCH("sets_prefix")) {
         config->prefixes[SET] = strdup(value);
+    } else if (NAME_MATCH("extended_counters_include")) {
+        csv_to_extended_counters_config(config, value);
     } else if (NAME_MATCH("kv_prefix")) {
         config->prefixes[KEY_VAL] = strdup(value);
-
     // Copy the multi-case variables
     } else if (NAME_MATCH("log_facility")) {
         return name_to_facility(value, &config->syslog_log_facility);
-
     // Unknown parameter?
     } else {
         // Log it, but ignore
@@ -367,6 +417,11 @@ int config_from_filename(char *filename, statsite_config *config) {
     // If there is no filename, return now
     if (filename == NULL)
         return 0;
+
+
+    // Initialize extended counters config
+    *extended_counters_cfg = (extended_counters_config){true, true, true, true, true, true, true, true};
+    config->ext_counters_config = extended_counters_cfg;
 
     // Try to open the file
     int res = ini_parse(filename, config_callback, config);
@@ -568,7 +623,17 @@ int sane_quantiles(int num_quantiles, double quantiles[]) {
  * @return a pointer to a new config structure on success.
  */
 statsite_config* alloc_config() {
-    return calloc(1, sizeof(statsite_config));
+
+    statsite_config* config = calloc(1, sizeof(statsite_config));
+
+    /**
+     * Also need to allocated memory for the extended counters config structure
+     */    
+    extended_counters_cfg = calloc(1, sizeof(extended_counters_config));
+    *extended_counters_cfg = (extended_counters_config){true, true, true, true, true, true, true, true};
+    config->ext_counters_config = extended_counters_cfg;
+    
+    return config;
 }
 
 /**
@@ -579,6 +644,7 @@ void free_config(statsite_config* config) {
     if (config->quantiles != default_quantiles) {
         free (config->quantiles);
     }
+    free(config->ext_counters_config);
     free(config);
 }
 

--- a/src/config.h
+++ b/src/config.h
@@ -17,6 +17,17 @@ typedef enum {
 
 #define METRIC_TYPES 7
 
+typedef struct extended_counters_config {
+    bool count;
+    bool mean;
+    bool stdev;
+    bool sum;
+    bool sum_sq;
+    bool lower;
+    bool upper;
+    bool rate;
+} extended_counters_config;
+
 // Represents the configuration of a histogram
 typedef struct histogram_config {
     char *prefix;
@@ -57,6 +68,7 @@ typedef struct {
     char* prefixes[METRIC_TYPES];
     char* prefixes_final[METRIC_TYPES];
     bool extended_counters;
+    extended_counters_config *ext_counters_config;
     bool prefix_binary_stream;
     int num_quantiles;
     double* quantiles;

--- a/src/config.h
+++ b/src/config.h
@@ -68,7 +68,7 @@ typedef struct {
     char* prefixes[METRIC_TYPES];
     char* prefixes_final[METRIC_TYPES];
     bool extended_counters;
-    extended_counters_config *ext_counters_config;
+    extended_counters_config ext_counters_config;
     bool prefix_binary_stream;
     int num_quantiles;
     double* quantiles;

--- a/src/conn_handler.c
+++ b/src/conn_handler.c
@@ -97,7 +97,7 @@ static int stream_formatter(FILE *pipe, void *data, metric_type type, char *name
     timer_hist *t;
     int i;
     char *prefix = GLOBAL_CONFIG->prefixes_final[type];
-    extended_counters_config* counters_config = GLOBAL_CONFIG->ext_counters_config;
+    extended_counters_config* counters_config = &(GLOBAL_CONFIG->ext_counters_config);
 
     switch (type) {
         case KEY_VAL:
@@ -216,7 +216,7 @@ static int stream_formatter_bin(FILE *pipe, void *data, metric_type type, char *
     timer_hist *t;
     int i;
 
-    extended_counters_config* counters_config = GLOBAL_CONFIG->ext_counters_config;
+    extended_counters_config* counters_config = &(GLOBAL_CONFIG->ext_counters_config);
 
     switch (type) {
         case KEY_VAL:

--- a/src/conn_handler.c
+++ b/src/conn_handler.c
@@ -97,6 +97,8 @@ static int stream_formatter(FILE *pipe, void *data, metric_type type, char *name
     timer_hist *t;
     int i;
     char *prefix = GLOBAL_CONFIG->prefixes_final[type];
+    extended_counters_config* counters_config = GLOBAL_CONFIG->ext_counters_config;
+
     switch (type) {
         case KEY_VAL:
             STREAM("%s%s|%f|%lld\n", prefix, name, *(double*)value);
@@ -108,14 +110,30 @@ static int stream_formatter(FILE *pipe, void *data, metric_type type, char *name
 
         case COUNTER:
             if (GLOBAL_CONFIG->extended_counters) {
-                STREAM("%s%s.count|%lld|%lld\n", prefix, name, counter_count(value));
-                STREAM("%s%s.mean|%f|%lld\n", prefix, name, counter_mean(value));
-                STREAM("%s%s.stdev|%f|%lld\n", prefix, name, counter_stddev(value));
-                STREAM("%s%s.sum|%f|%lld\n", prefix, name, counter_sum(value));
-                STREAM("%s%s.sum_sq|%f|%lld\n", prefix, name, counter_squared_sum(value));
-                STREAM("%s%s.lower|%f|%lld\n", prefix, name, counter_min(value));
-                STREAM("%s%s.upper|%f|%lld\n", prefix, name, counter_max(value));
-                STREAM("%s%s.rate|%f|%lld\n", prefix, name, counter_sum(value) / GLOBAL_CONFIG->flush_interval);
+                if (counters_config->count) {
+                    STREAM("%s%s.count|%lld|%lld\n", prefix, name, counter_count(value));
+                }
+                if (counters_config->mean) {
+                    STREAM("%s%s.mean|%f|%lld\n", prefix, name, counter_mean(value));    
+                }
+                if (counters_config->stdev) {
+                    STREAM("%s%s.stdev|%f|%lld\n", prefix, name, counter_stddev(value));
+                }
+                if (counters_config->sum) {
+                    STREAM("%s%s.sum|%f|%lld\n", prefix, name, counter_sum(value));
+                }
+                if (counters_config->sum_sq) {
+                    STREAM("%s%s.sum_sq|%f|%lld\n", prefix, name, counter_squared_sum(value));
+                }
+                if (counters_config->lower) {
+                    STREAM("%s%s.lower|%f|%lld\n", prefix, name, counter_min(value));
+                }
+                if (counters_config->upper) {
+                    STREAM("%s%s.upper|%f|%lld\n", prefix, name, counter_max(value));
+                }
+                if (counters_config->rate) {
+                    STREAM("%s%s.rate|%f|%lld\n", prefix, name, counter_sum(value) / GLOBAL_CONFIG->flush_interval);
+                }
             } else {
                 STREAM("%s%s|%f|%lld\n", prefix, name, counter_sum(value));
             }
@@ -197,6 +215,9 @@ static int stream_formatter_bin(FILE *pipe, void *data, metric_type type, char *
     #define STREAM_UINT(val) if (!fwrite(&val, sizeof(unsigned int), 1, pipe)) return 1;
     timer_hist *t;
     int i;
+
+    extended_counters_config* counters_config = GLOBAL_CONFIG->ext_counters_config;
+
     switch (type) {
         case KEY_VAL:
             STREAM_BIN(BIN_TYPE_KV, BIN_OUT_NO_TYPE, *(double*)value);
@@ -207,14 +228,30 @@ static int stream_formatter_bin(FILE *pipe, void *data, metric_type type, char *
             break;
 
         case COUNTER:
-            STREAM_BIN(BIN_TYPE_COUNTER, BIN_OUT_SUM, counter_sum(value));
-            STREAM_BIN(BIN_TYPE_COUNTER, BIN_OUT_SUM_SQ, counter_squared_sum(value));
-            STREAM_BIN(BIN_TYPE_COUNTER, BIN_OUT_MEAN, counter_mean(value));
-            STREAM_BIN(BIN_TYPE_COUNTER, BIN_OUT_COUNT, counter_count(value));
-            STREAM_BIN(BIN_TYPE_COUNTER, BIN_OUT_STDDEV, counter_stddev(value));
-            STREAM_BIN(BIN_TYPE_COUNTER, BIN_OUT_MIN, counter_min(value));
-            STREAM_BIN(BIN_TYPE_COUNTER, BIN_OUT_MAX, counter_max(value));
-            STREAM_BIN(BIN_TYPE_COUNTER, BIN_OUT_RATE, counter_sum(value) / GLOBAL_CONFIG->flush_interval);
+            if (counters_config->sum) {
+                STREAM_BIN(BIN_TYPE_COUNTER, BIN_OUT_SUM, counter_sum(value));
+            }
+            if (counters_config->sum_sq) {
+                STREAM_BIN(BIN_TYPE_COUNTER, BIN_OUT_SUM_SQ, counter_squared_sum(value));
+            }
+            if (counters_config->mean) {
+                STREAM_BIN(BIN_TYPE_COUNTER, BIN_OUT_MEAN, counter_mean(value));
+            }
+            if (counters_config->count) {
+                STREAM_BIN(BIN_TYPE_COUNTER, BIN_OUT_COUNT, counter_count(value));
+            }
+            if (counters_config->stdev) {
+                STREAM_BIN(BIN_TYPE_COUNTER, BIN_OUT_STDDEV, counter_stddev(value));
+            }
+            if (counters_config->lower) {
+                STREAM_BIN(BIN_TYPE_COUNTER, BIN_OUT_MIN, counter_min(value));
+            }
+            if (counters_config->upper) {    
+                STREAM_BIN(BIN_TYPE_COUNTER, BIN_OUT_MAX, counter_max(value));
+            }
+            if (counters_config->rate) {    
+                STREAM_BIN(BIN_TYPE_COUNTER, BIN_OUT_RATE, counter_sum(value) / GLOBAL_CONFIG->flush_interval);
+            }
             break;
 
         case SET:

--- a/src/statsite.c
+++ b/src/statsite.c
@@ -138,7 +138,6 @@ int main(int argc, char **argv) {
 
     // Parse the config file
     statsite_config *config = alloc_config();
-
     int config_res = config_from_filename(config_file, config);
     if (config_res != 0) {
         syslog(LOG_ERR, "Failed to read the configuration file!");

--- a/src/statsite.c
+++ b/src/statsite.c
@@ -138,6 +138,7 @@ int main(int argc, char **argv) {
 
     // Parse the config file
     statsite_config *config = alloc_config();
+
     int config_res = config_from_filename(config_file, config);
     if (config_res != 0) {
         syslog(LOG_ERR, "Failed to read the configuration file!");

--- a/tests/runner.c
+++ b/tests/runner.c
@@ -121,7 +121,11 @@ int main(void)
     tcase_add_test(tc8, test_sane_prefixes);
     tcase_add_test(tc8, test_sane_global_prefix);
     tcase_add_test(tc8, test_sane_quantiles);
-    
+    tcase_add_test(tc8, test_extended_counters_include_count_only);
+    tcase_add_test(tc8, test_extended_counters_include_count_rate);
+    tcase_add_test(tc8, test_extended_counters_include_all_selected);
+    tcase_add_test(tc8, test_extended_counters_include_all_by_default);
+
     // Add the radix tests
     suite_add_tcase(s1, tc9);
     tcase_add_test(tc9, test_radix_init_and_destroy);

--- a/tests/test_config.c
+++ b/tests/test_config.c
@@ -27,6 +27,14 @@ START_TEST(test_config_get_default)
     fail_unless(strcmp(config.pid_file, "/var/run/statsite.pid") == 0);
     fail_unless(config.input_counter == NULL);
     fail_unless(config.extended_counters == false);
+    fail_unless(config.ext_counters_config.count == true);
+    fail_unless(config.ext_counters_config.mean == true);
+    fail_unless(config.ext_counters_config.stdev == true);
+    fail_unless(config.ext_counters_config.sum == true);
+    fail_unless(config.ext_counters_config.sum_sq == true);
+    fail_unless(config.ext_counters_config.lower == true);
+    fail_unless(config.ext_counters_config.upper == true);
+    fail_unless(config.ext_counters_config.rate == true);
     fail_unless(config.prefix_binary_stream == false);
     fail_unless(config.num_quantiles == 3);
     fail_unless(config.quantiles[0] == 0.5);
@@ -56,6 +64,14 @@ START_TEST(test_config_bad_file)
     fail_unless(strcmp(config.pid_file, "/var/run/statsite.pid") == 0);
     fail_unless(config.input_counter == NULL);
     fail_unless(config.extended_counters == false);
+    fail_unless(config.ext_counters_config.count == true);
+    fail_unless(config.ext_counters_config.mean == true);
+    fail_unless(config.ext_counters_config.stdev == true);
+    fail_unless(config.ext_counters_config.sum == true);
+    fail_unless(config.ext_counters_config.sum_sq == true);
+    fail_unless(config.ext_counters_config.lower == true);
+    fail_unless(config.ext_counters_config.upper == true);
+    fail_unless(config.ext_counters_config.rate == true);
     fail_unless(config.prefix_binary_stream == false);
     fail_unless(config.num_quantiles == 3);
     fail_unless(config.quantiles[0] == 0.5);
@@ -90,6 +106,14 @@ START_TEST(test_config_empty_file)
     fail_unless(strcmp(config.pid_file, "/var/run/statsite.pid") == 0);
     fail_unless(config.input_counter == NULL);
     fail_unless(config.extended_counters == false);
+    fail_unless(config.ext_counters_config.count == true);
+    fail_unless(config.ext_counters_config.mean == true);
+    fail_unless(config.ext_counters_config.stdev == true);
+    fail_unless(config.ext_counters_config.sum == true);
+    fail_unless(config.ext_counters_config.sum_sq == true);
+    fail_unless(config.ext_counters_config.lower == true);
+    fail_unless(config.ext_counters_config.upper == true);
+    fail_unless(config.ext_counters_config.rate == true);
     fail_unless(config.prefix_binary_stream == false);
     fail_unless(config.num_quantiles == 3);
     fail_unless(config.quantiles[0] == 0.5);
@@ -566,5 +590,260 @@ sets_prefix=foo.sets.bar.";
     fail_unless(strcmp(config.prefixes_final[TIMER], "statsd.timers.") == 0);
     fail_unless(strcmp(config.prefixes_final[COUNTER], "statsd.counts.") == 0);
     unlink("/tmp/global_prefix");
+}
+END_TEST
+
+START_TEST(test_extended_counters_include_count_only)
+{
+    int fh = open("/tmp/extended_counters_include_count_config", O_CREAT|O_RDWR, 0777);
+    char *buf = "[statsite]\n\
+port = 10000\n\
+udp_port = 10001\n\
+parse_stdin = true\n\
+flush_interval = 120\n\
+timer_eps = 0.005\n\
+set_eps = 0.03\n\
+stream_cmd = foo\n\
+log_level = INFO\n\
+log_facility = local3\n\
+daemonize = true\n\
+binary_stream = true\n\
+input_counter = foobar\n\
+pid_file = /tmp/statsite.pid\n\
+extended_counters = true\n\
+extended_counters_include = COUNT\n\
+prefix_binary_stream = true\n\
+quantiles = 0.5, 0.90, 0.95, 0.99\n";
+    write(fh, buf, strlen(buf));
+    fchmod(fh, 777);
+    close(fh);
+
+    statsite_config config;
+    int res = config_from_filename("/tmp/extended_counters_include_count_config", &config);
+    fail_unless(res == 0);
+
+    // Should get the config
+    fail_unless(config.tcp_port == 10000);
+    fail_unless(config.udp_port == 10001);
+    fail_unless(config.parse_stdin == true);
+    fail_unless(strcmp(config.log_level, "INFO") == 0);
+    fail_unless(strcmp(config.log_facility, "local3") == 0);
+    fail_unless(config.timer_eps == (double)0.005);
+    fail_unless(config.set_eps == (double)0.03);
+    fail_unless(strcmp(config.stream_cmd, "foo") == 0);
+    fail_unless(config.flush_interval == 120);
+    fail_unless(config.daemonize == true);
+    fail_unless(config.binary_stream == true);
+    fail_unless(strcmp(config.pid_file, "/tmp/statsite.pid") == 0);
+    fail_unless(strcmp(config.input_counter, "foobar") == 0);
+    fail_unless(config.extended_counters == true);
+    // Only the count extended counter should be included
+    fail_unless(config.ext_counters_config.count == true);
+    fail_unless(config.ext_counters_config.mean == false);
+    fail_unless(config.ext_counters_config.stdev == false);
+    fail_unless(config.ext_counters_config.sum == false);
+    fail_unless(config.ext_counters_config.sum_sq == false);
+    fail_unless(config.ext_counters_config.lower == false);
+    fail_unless(config.ext_counters_config.upper == false);
+    fail_unless(config.ext_counters_config.rate == false);
+    fail_unless(config.prefix_binary_stream == true);
+    fail_unless(config.num_quantiles == 4);
+    fail_unless(config.quantiles[0] == 0.5);
+    fail_unless(config.quantiles[1] == 0.90);
+    fail_unless(config.quantiles[2] == 0.95);
+    fail_unless(config.quantiles[3] == 0.99);
+
+    unlink("/tmp/extended_counters_include_count_config");
+}
+END_TEST
+
+START_TEST(test_extended_counters_include_count_rate)
+{
+    int fh = open("/tmp/extended_counters_include_count_rate_config", O_CREAT|O_RDWR, 0777);
+    char *buf = "[statsite]\n\
+port = 10000\n\
+udp_port = 10001\n\
+parse_stdin = true\n\
+flush_interval = 120\n\
+timer_eps = 0.005\n\
+set_eps = 0.03\n\
+stream_cmd = foo\n\
+log_level = INFO\n\
+log_facility = local3\n\
+daemonize = true\n\
+binary_stream = true\n\
+input_counter = foobar\n\
+pid_file = /tmp/statsite.pid\n\
+extended_counters = true\n\
+extended_counters_include = COUNT,RATE\n\
+prefix_binary_stream = true\n\
+quantiles = 0.5, 0.90, 0.95, 0.99\n";
+    write(fh, buf, strlen(buf));
+    fchmod(fh, 777);
+    close(fh);
+
+    statsite_config config;
+    int res = config_from_filename("/tmp/extended_counters_include_count_rate_config", &config);
+    fail_unless(res == 0);
+
+    // Should get the config
+    fail_unless(config.tcp_port == 10000);
+    fail_unless(config.udp_port == 10001);
+    fail_unless(config.parse_stdin == true);
+    fail_unless(strcmp(config.log_level, "INFO") == 0);
+    fail_unless(strcmp(config.log_facility, "local3") == 0);
+    fail_unless(config.timer_eps == (double)0.005);
+    fail_unless(config.set_eps == (double)0.03);
+    fail_unless(strcmp(config.stream_cmd, "foo") == 0);
+    fail_unless(config.flush_interval == 120);
+    fail_unless(config.daemonize == true);
+    fail_unless(config.binary_stream == true);
+    fail_unless(strcmp(config.pid_file, "/tmp/statsite.pid") == 0);
+    fail_unless(strcmp(config.input_counter, "foobar") == 0);
+    fail_unless(config.extended_counters == true);
+    // Both count and rate extended counters should be included
+    fail_unless(config.ext_counters_config.count == true);
+    fail_unless(config.ext_counters_config.mean == false);
+    fail_unless(config.ext_counters_config.stdev == false);
+    fail_unless(config.ext_counters_config.sum == false);
+    fail_unless(config.ext_counters_config.sum_sq == false);
+    fail_unless(config.ext_counters_config.lower == false);
+    fail_unless(config.ext_counters_config.upper == false);
+    fail_unless(config.ext_counters_config.rate == true);
+    fail_unless(config.prefix_binary_stream == true);
+    fail_unless(config.num_quantiles == 4);
+    fail_unless(config.quantiles[0] == 0.5);
+    fail_unless(config.quantiles[1] == 0.90);
+    fail_unless(config.quantiles[2] == 0.95);
+    fail_unless(config.quantiles[3] == 0.99);
+
+    unlink("/tmp/extended_counters_include_count_rate_config");
+}
+END_TEST
+
+START_TEST(test_extended_counters_include_all_selected)
+{
+    int fh = open("/tmp/extended_counters_include_all_selected_config", O_CREAT|O_RDWR, 0777);
+    char *buf = "[statsite]\n\
+port = 10000\n\
+udp_port = 10001\n\
+parse_stdin = true\n\
+flush_interval = 120\n\
+timer_eps = 0.005\n\
+set_eps = 0.03\n\
+stream_cmd = foo\n\
+log_level = INFO\n\
+log_facility = local3\n\
+daemonize = true\n\
+binary_stream = true\n\
+input_counter = foobar\n\
+pid_file = /tmp/statsite.pid\n\
+extended_counters = true\n\
+extended_counters_include = COUNT,MEAN,STDEV,SUM,SUM_SQ,LOWER,UPPER,RATE\n\
+prefix_binary_stream = true\n\
+quantiles = 0.5, 0.90, 0.95, 0.99\n";
+    write(fh, buf, strlen(buf));
+    fchmod(fh, 777);
+    close(fh);
+
+    statsite_config config;
+    int res = config_from_filename("/tmp/extended_counters_include_all_selected_config", &config);
+    fail_unless(res == 0);
+
+    // Should get the config
+    fail_unless(config.tcp_port == 10000);
+    fail_unless(config.udp_port == 10001);
+    fail_unless(config.parse_stdin == true);
+    fail_unless(strcmp(config.log_level, "INFO") == 0);
+    fail_unless(strcmp(config.log_facility, "local3") == 0);
+    fail_unless(config.timer_eps == (double)0.005);
+    fail_unless(config.set_eps == (double)0.03);
+    fail_unless(strcmp(config.stream_cmd, "foo") == 0);
+    fail_unless(config.flush_interval == 120);
+    fail_unless(config.daemonize == true);
+    fail_unless(config.binary_stream == true);
+    fail_unless(strcmp(config.pid_file, "/tmp/statsite.pid") == 0);
+    fail_unless(strcmp(config.input_counter, "foobar") == 0);
+    fail_unless(config.extended_counters == true);
+    // Since all extended counters were included they should all be selected
+    fail_unless(config.ext_counters_config.count == true);
+    fail_unless(config.ext_counters_config.mean == true);
+    fail_unless(config.ext_counters_config.stdev == true);
+    fail_unless(config.ext_counters_config.sum == true);
+    fail_unless(config.ext_counters_config.sum_sq == true);
+    fail_unless(config.ext_counters_config.lower == true);
+    fail_unless(config.ext_counters_config.upper == true);
+    fail_unless(config.ext_counters_config.rate == true);
+    fail_unless(config.prefix_binary_stream == true);
+    fail_unless(config.num_quantiles == 4);
+    fail_unless(config.quantiles[0] == 0.5);
+    fail_unless(config.quantiles[1] == 0.90);
+    fail_unless(config.quantiles[2] == 0.95);
+    fail_unless(config.quantiles[3] == 0.99);
+
+    unlink("/tmp/extended_counters_include_all_selected_config");
+}
+END_TEST
+
+START_TEST(test_extended_counters_include_all_by_default)
+{
+    int fh = open("/tmp/extended_counters_include_all_by_default_config", O_CREAT|O_RDWR, 0777);
+    char *buf = "[statsite]\n\
+port = 10000\n\
+udp_port = 10001\n\
+parse_stdin = true\n\
+flush_interval = 120\n\
+timer_eps = 0.005\n\
+set_eps = 0.03\n\
+stream_cmd = foo\n\
+log_level = INFO\n\
+log_facility = local3\n\
+daemonize = true\n\
+binary_stream = true\n\
+input_counter = foobar\n\
+pid_file = /tmp/statsite.pid\n\
+extended_counters = true\n\
+prefix_binary_stream = true\n\
+quantiles = 0.5, 0.90, 0.95, 0.99\n";
+    write(fh, buf, strlen(buf));
+    fchmod(fh, 777);
+    close(fh);
+
+    statsite_config config;
+    int res = config_from_filename("/tmp/extended_counters_include_all_by_default_config", &config);
+    fail_unless(res == 0);
+
+    // Should get the config
+    fail_unless(config.tcp_port == 10000);
+    fail_unless(config.udp_port == 10001);
+    fail_unless(config.parse_stdin == true);
+    fail_unless(strcmp(config.log_level, "INFO") == 0);
+    fail_unless(strcmp(config.log_facility, "local3") == 0);
+    fail_unless(config.timer_eps == (double)0.005);
+    fail_unless(config.set_eps == (double)0.03);
+    fail_unless(strcmp(config.stream_cmd, "foo") == 0);
+    fail_unless(config.flush_interval == 120);
+    fail_unless(config.daemonize == true);
+    fail_unless(config.binary_stream == true);
+    fail_unless(strcmp(config.pid_file, "/tmp/statsite.pid") == 0);
+    fail_unless(strcmp(config.input_counter, "foobar") == 0);
+    fail_unless(config.extended_counters == true);
+    // If the extended_counters_include config property is not in the config file all extended counters should be included by default
+    fail_unless(config.ext_counters_config.count == true);
+    fail_unless(config.ext_counters_config.mean == true);
+    fail_unless(config.ext_counters_config.stdev == true);
+    fail_unless(config.ext_counters_config.sum == true);
+    fail_unless(config.ext_counters_config.sum_sq == true);
+    fail_unless(config.ext_counters_config.lower == true);
+    fail_unless(config.ext_counters_config.upper == true);
+    fail_unless(config.ext_counters_config.rate == true);
+    fail_unless(config.prefix_binary_stream == true);
+    fail_unless(config.num_quantiles == 4);
+    fail_unless(config.quantiles[0] == 0.5);
+    fail_unless(config.quantiles[1] == 0.90);
+    fail_unless(config.quantiles[2] == 0.95);
+    fail_unless(config.quantiles[3] == 0.99);
+
+    unlink("/tmp/extended_counters_include_all_by_default_config");
 }
 END_TEST


### PR DESCRIPTION
Hey,

Would you like to add the ability to specify which extended counters to include? If yes does it need any changes?
I made it backwards compatible so if the new config is not set all extended counters will be included. All tests still pass.

fyi, we are running statsite to send close 1 million metrics per second to graphite we have 16 statsite daemons running in 16 servers. With the original Node.js statsd implementation + proxies each server used to have 6 cores at 100% usage. With statsite I'm getting 1 core at less than 20% usage for the same amount of metrics.

Thanks,
Gihad