### PR TITLE
Small bugfixes

### DIFF
--- a/sinks/graphite.py
+++ b/sinks/graphite.py
@@ -65,23 +65,33 @@ class GraphiteStore(object):
         Closes the connection. The socket will be recreated on the next
         flush.
         """
-        self.sock.close()
+        try:
+            if self.sock:
+                self.sock.close()
+        except:
+            self.logger.warning("Failed to close connection!")
 
     def _create_socket(self):
         """Creates a socket and connects to the graphite server"""
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.connect((self.host, self.port))
+        try:
+            sock.connect((self.host, self.port))
+        except:
+            self.logger.error("Failed to connect!")
+            sock = None
         return sock
 
     def _write_metric(self, metric):
         """Tries to write a string to the socket, reconnecting on any errors"""
         for attempt in xrange(self.attempts):
-            try:
-                self.sock.sendall(metric)
-                return
-            except socket.error:
-                self.logger.exception("Error while flushing to graphite. Reattempting...")
-                self.sock = self._create_socket()
+            if self.sock:
+                try:
+                    self.sock.sendall(metric)
+                    return
+                except socket.error:
+                    self.logger.exception("Error while flushing to graphite. Reattempting...")
+
+            self.sock = self._create_socket()
 
         self.logger.critical("Failed to flush to Graphite! Gave up after %d attempts." % self.attempts)
 

--- a/sinks/graphite.py
+++ b/sinks/graphite.py
@@ -24,7 +24,7 @@ class GraphiteStore(object):
 
         if port <= 0:
             raise ValueError("Port must be positive!")
-        if attempts <= 1:
+        if attempts < 1:
             raise ValueError("Must have at least 1 attempt!")
 
         self.host = host


### PR DESCRIPTION
We noticed some problems with the graphite sink producing uncaught exceptions if the graphite backend is not available. This bugfixes solved these problems for us.

We use the graphite sink with attemps=1 (no retry).