### PR TITLE
remove broken call to configtest from statsite init script

### DIFF
--- a/rpm/statsite.initscript
+++ b/rpm/statsite.initscript
@@ -71,7 +71,6 @@ case "$1" in
         RETVAL=$?
         ;;
     restart)
-        configtest -q || exit $RETVAL
         stop
         start
         ;;


### PR DESCRIPTION
This function isn't defined anywhere and makes the `restart` command fail.