### PR TITLE
Timers include

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,9 +204,14 @@ options must exist in the `statsite` section of the INI file:
   `lower`, `upper`, and `rate`.
   Defaults to false.
 
-* extended\_counters\_include : Allows you to configure which extended counters to include 
+* extended\_counters\_include : Allows you to configure which extended counters to include
   through a comma separated list of values, extended\_counters must be set to true. Supported values include `count`, `mean`, `stdev`, `sum`, `sum_sq`,
   `lower`, `upper`, and `rate`. If this option is not specified but extended_counters is set to true, then all values will be included by default.
+
+* timers\_include : Allows you to configure which timer metrics to include
+  through a comma separated list of values. Supported values include `count`, `mean`, `stdev`, `sum`, `sum_sq`,
+  `lower`, `upper`, `rate`, `median` and `sample_rate`. If this option is not specified then all values except `median` will be included by default.
+  `median` will be included if `quantiles` include 0.5
 
 * prefix\_binary\_stream : If enabled, the keys streamed to a the stream\_cmd
   when using binary\_stream mode are also prefixed. By default, this is false,

--- a/integ/test_timers_include.py
+++ b/integ/test_timers_include.py
@@ -1,0 +1,114 @@
+import os
+import os.path
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import random
+
+try:
+    import pytest
+except ImportError:
+    print >> sys.stderr, "Integ tests require pytests!"
+    sys.exit(1)
+
+
+def pytest_funcarg__servers(request):
+    "Returns a new APIHandler with a filter manager"
+    # Create tmpdir and delete after
+    tmpdir = tempfile.mkdtemp()
+
+    # Make the command
+    output = "%s/output" % tmpdir
+    cmd = "cat >> %s" % output
+
+    # Write the configuration
+    port = random.randrange(10000, 65000)
+    config_path = os.path.join(tmpdir, "config.cfg")
+    conf = """[statsite]
+flush_interval = 1
+port = %d
+udp_port = %d
+stream_cmd = %s
+timers_include = MEAN,STDEV,SUM,SUM_SQ,LOWER,UPPER,SAMPLE_RATE
+
+""" % (port, port, cmd)
+    open(config_path, "w").write(conf)
+
+    # Start the process
+    proc = subprocess.Popen(['./statsite', '-f', config_path])
+    proc.poll()
+    assert proc.returncode is None
+
+    # Define a cleanup handler
+    def cleanup():
+        try:
+            proc.kill()
+            proc.wait()
+            shutil.rmtree(tmpdir)
+        except:
+            print proc
+            pass
+    request.addfinalizer(cleanup)
+
+    # Make a connection to the server
+    connected = False
+    for x in xrange(3):
+        try:
+            conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            conn.settimeout(1)
+            conn.connect(("localhost", port))
+            connected = True
+            break
+        except Exception, e:
+            print e
+            time.sleep(0.5)
+
+    # Die now
+    if not connected:
+        raise EnvironmentError("Failed to connect!")
+
+    # Make a second connection
+    conn2 = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    conn2.connect(("localhost", port))
+
+    # Return the connection
+    return conn, conn2, output
+
+
+def wait_file(path, timeout=5):
+    "Waits on a file to be make"
+    start = time.time()
+    while not os.path.isfile(path) and time.time() - start < timeout:
+        time.sleep(0.1)
+    if not os.path.isfile(path):
+        raise Exception("Timed out waiting for file %s" % path)
+    while os.path.getsize(path) == 0 and time.time() - start < timeout:
+        time.sleep(0.1)
+
+
+class TestInteg(object):
+    def test_counters(self, servers):
+        "Tests adding kv pairs"
+        server, _, output = servers
+        server.sendall("foobar:100|ms\n")
+        server.sendall("foobar:200|ms\n")
+        server.sendall("foobar:300|ms\n")
+
+        wait_file(output)
+        out = open(output).read()
+        assert "timers.foobar.count" not in out
+        assert "timers.foobar.rate" not in out
+        assert "timers.foobar.mean|200" in out
+        assert "timers.foobar.stdev|100" in out
+        assert "timers.foobar.sum|600" in out
+        assert "timers.foobar.sum_sq|140000" in out
+        assert "timers.foobar.lower|100" in out
+        assert "timers.foobar.upper|300" in out
+        assert "timers.foobar.median" not in out
+        assert "timers.foobar.p50|200" in out
+        assert "timers.foobar.sample_rate|3" in out
+
+

--- a/src/config.h
+++ b/src/config.h
@@ -17,7 +17,7 @@ typedef enum {
 
 #define METRIC_TYPES 7
 
-typedef struct extended_counters_config {
+typedef struct included_metrics_config {
     bool count;
     bool mean;
     bool stdev;
@@ -26,7 +26,9 @@ typedef struct extended_counters_config {
     bool lower;
     bool upper;
     bool rate;
-} extended_counters_config;
+    bool median;
+    bool sample_rate;
+} included_metrics_config;
 
 // Represents the configuration of a histogram
 typedef struct histogram_config {
@@ -68,7 +70,8 @@ typedef struct {
     char* prefixes[METRIC_TYPES];
     char* prefixes_final[METRIC_TYPES];
     bool extended_counters;
-    extended_counters_config ext_counters_config;
+    included_metrics_config ext_counters_config;
+    included_metrics_config timers_config;
     bool prefix_binary_stream;
     int num_quantiles;
     double* quantiles;

--- a/tests/runner.c
+++ b/tests/runner.c
@@ -127,6 +127,9 @@ int main(void)
     tcase_add_test(tc8, test_extended_counters_include_count_rate);
     tcase_add_test(tc8, test_extended_counters_include_all_selected);
     tcase_add_test(tc8, test_extended_counters_include_all_by_default);
+    tcase_add_test(tc8, test_timers_include_count_only);
+    tcase_add_test(tc8, test_timers_include_count_rate);
+    tcase_add_test(tc8, test_timers_include_all_selected);
 
     // Add the radix tests
     suite_add_tcase(s1, tc9);

--- a/tests/test_config.c
+++ b/tests/test_config.c
@@ -894,7 +894,7 @@ END_TEST
 
 START_TEST(test_timers_include_count_only)
 {
-    int fh = open("/tmp/extended_counters_include_count_config", O_CREAT|O_RDWR, 0777);
+    int fh = open("/tmp/timers_include_count_config", O_CREAT|O_RDWR, 0777);
     char *buf = "[statsite]\n\
 timers_include = COUNT\n";
     write(fh, buf, strlen(buf));
@@ -902,7 +902,7 @@ timers_include = COUNT\n";
     close(fh);
 
     statsite_config config;
-    int res = config_from_filename("/tmp/extended_counters_include_count_config", &config);
+    int res = config_from_filename("/tmp/timers_include_count_config", &config);
     fail_unless(res == 0);
 
     // Should get the config
@@ -917,13 +917,13 @@ timers_include = COUNT\n";
     fail_unless(config.timers_config.median == false);
     fail_unless(config.timers_config.sample_rate == false);
 
-    unlink("/tmp/extended_counters_include_count_config");
+    unlink("/tmp/timers_include_count_config");
 }
 END_TEST
 
 START_TEST(test_timers_include_count_rate)
 {
-    int fh = open("/tmp/extended_counters_include_count_config", O_CREAT|O_RDWR, 0777);
+    int fh = open("/tmp/timers_include_count_rate_config", O_CREAT|O_RDWR, 0777);
     char *buf = "[statsite]\n\
 timers_include = COUNT,RATE\n";
     write(fh, buf, strlen(buf));
@@ -931,7 +931,7 @@ timers_include = COUNT,RATE\n";
     close(fh);
 
     statsite_config config;
-    int res = config_from_filename("/tmp/extended_counters_include_count_config", &config);
+    int res = config_from_filename("/tmp/timers_include_count_rate_config", &config);
     fail_unless(res == 0);
 
     // Should get the config
@@ -946,13 +946,13 @@ timers_include = COUNT,RATE\n";
     fail_unless(config.timers_config.median == false);
     fail_unless(config.timers_config.sample_rate == false);
 
-    unlink("/tmp/extended_counters_include_count_config");
+    unlink("/tmp/timers_include_count_rate_config");
 }
 END_TEST
 
 START_TEST(test_timers_include_all_selected)
 {
-    int fh = open("/tmp/extended_counters_include_count_config", O_CREAT|O_RDWR, 0777);
+    int fh = open("/tmp/timers_include_all_selected_config", O_CREAT|O_RDWR, 0777);
     char *buf = "[statsite]\n\
 timers_include = COUNT,MEAN,STDEV,SUM,SUM_SQ,LOWER,UPPER,RATE,MEDIAN,SAMPLE_RATE\n";
     write(fh, buf, strlen(buf));
@@ -960,7 +960,7 @@ timers_include = COUNT,MEAN,STDEV,SUM,SUM_SQ,LOWER,UPPER,RATE,MEDIAN,SAMPLE_RATE
     close(fh);
 
     statsite_config config;
-    int res = config_from_filename("/tmp/extended_counters_include_count_config", &config);
+    int res = config_from_filename("/tmp/timers_include_all_selected_config", &config);
     fail_unless(res == 0);
 
     // Should get the config
@@ -975,6 +975,6 @@ timers_include = COUNT,MEAN,STDEV,SUM,SUM_SQ,LOWER,UPPER,RATE,MEDIAN,SAMPLE_RATE
     fail_unless(config.timers_config.median == true);
     fail_unless(config.timers_config.sample_rate == true);
 
-    unlink("/tmp/extended_counters_include_count_config");
+    unlink("/tmp/timers_include_all_selected_config");
 }
 END_TEST

--- a/tests/test_config.c
+++ b/tests/test_config.c
@@ -35,6 +35,18 @@ START_TEST(test_config_get_default)
     fail_unless(config.ext_counters_config.lower == true);
     fail_unless(config.ext_counters_config.upper == true);
     fail_unless(config.ext_counters_config.rate == true);
+    fail_unless(config.ext_counters_config.median == false);
+    fail_unless(config.ext_counters_config.sample_rate == false);
+    fail_unless(config.timers_config.count == true);
+    fail_unless(config.timers_config.mean == true);
+    fail_unless(config.timers_config.stdev == true);
+    fail_unless(config.timers_config.sum == true);
+    fail_unless(config.timers_config.sum_sq == true);
+    fail_unless(config.timers_config.lower == true);
+    fail_unless(config.timers_config.upper == true);
+    fail_unless(config.timers_config.rate == true);
+    fail_unless(config.timers_config.median == true);
+    fail_unless(config.timers_config.sample_rate == true);
     fail_unless(config.prefix_binary_stream == false);
     fail_unless(config.num_quantiles == 3);
     fail_unless(config.quantiles[0] == 0.5);
@@ -72,6 +84,18 @@ START_TEST(test_config_bad_file)
     fail_unless(config.ext_counters_config.lower == true);
     fail_unless(config.ext_counters_config.upper == true);
     fail_unless(config.ext_counters_config.rate == true);
+    fail_unless(config.ext_counters_config.median == false);
+    fail_unless(config.ext_counters_config.sample_rate == false);
+    fail_unless(config.timers_config.count == true);
+    fail_unless(config.timers_config.mean == true);
+    fail_unless(config.timers_config.stdev == true);
+    fail_unless(config.timers_config.sum == true);
+    fail_unless(config.timers_config.sum_sq == true);
+    fail_unless(config.timers_config.lower == true);
+    fail_unless(config.timers_config.upper == true);
+    fail_unless(config.timers_config.rate == true);
+    fail_unless(config.timers_config.median == true);
+    fail_unless(config.timers_config.sample_rate == true);
     fail_unless(config.prefix_binary_stream == false);
     fail_unless(config.num_quantiles == 3);
     fail_unless(config.quantiles[0] == 0.5);
@@ -114,6 +138,18 @@ START_TEST(test_config_empty_file)
     fail_unless(config.ext_counters_config.lower == true);
     fail_unless(config.ext_counters_config.upper == true);
     fail_unless(config.ext_counters_config.rate == true);
+    fail_unless(config.ext_counters_config.median == false);
+    fail_unless(config.ext_counters_config.sample_rate == false);
+    fail_unless(config.timers_config.count == true);
+    fail_unless(config.timers_config.mean == true);
+    fail_unless(config.timers_config.stdev == true);
+    fail_unless(config.timers_config.sum == true);
+    fail_unless(config.timers_config.sum_sq == true);
+    fail_unless(config.timers_config.lower == true);
+    fail_unless(config.timers_config.upper == true);
+    fail_unless(config.timers_config.rate == true);
+    fail_unless(config.timers_config.median == true);
+    fail_unless(config.timers_config.sample_rate == true);
     fail_unless(config.prefix_binary_stream == false);
     fail_unless(config.num_quantiles == 3);
     fail_unless(config.quantiles[0] == 0.5);
@@ -646,6 +682,8 @@ quantiles = 0.5, 0.90, 0.95, 0.99\n";
     fail_unless(config.ext_counters_config.lower == false);
     fail_unless(config.ext_counters_config.upper == false);
     fail_unless(config.ext_counters_config.rate == false);
+    fail_unless(config.ext_counters_config.median == false);
+    fail_unless(config.ext_counters_config.sample_rate == false);
     fail_unless(config.prefix_binary_stream == true);
     fail_unless(config.num_quantiles == 4);
     fail_unless(config.quantiles[0] == 0.5);
@@ -710,6 +748,8 @@ quantiles = 0.5, 0.90, 0.95, 0.99\n";
     fail_unless(config.ext_counters_config.lower == false);
     fail_unless(config.ext_counters_config.upper == false);
     fail_unless(config.ext_counters_config.rate == true);
+    fail_unless(config.ext_counters_config.median == false);
+    fail_unless(config.ext_counters_config.sample_rate == false);
     fail_unless(config.prefix_binary_stream == true);
     fail_unless(config.num_quantiles == 4);
     fail_unless(config.quantiles[0] == 0.5);
@@ -774,6 +814,8 @@ quantiles = 0.5, 0.90, 0.95, 0.99\n";
     fail_unless(config.ext_counters_config.lower == true);
     fail_unless(config.ext_counters_config.upper == true);
     fail_unless(config.ext_counters_config.rate == true);
+    fail_unless(config.ext_counters_config.median == false);
+    fail_unless(config.ext_counters_config.sample_rate == false);
     fail_unless(config.prefix_binary_stream == true);
     fail_unless(config.num_quantiles == 4);
     fail_unless(config.quantiles[0] == 0.5);
@@ -837,6 +879,8 @@ quantiles = 0.5, 0.90, 0.95, 0.99\n";
     fail_unless(config.ext_counters_config.lower == true);
     fail_unless(config.ext_counters_config.upper == true);
     fail_unless(config.ext_counters_config.rate == true);
+    fail_unless(config.ext_counters_config.median == false);
+    fail_unless(config.ext_counters_config.sample_rate == false);
     fail_unless(config.prefix_binary_stream == true);
     fail_unless(config.num_quantiles == 4);
     fail_unless(config.quantiles[0] == 0.5);
@@ -845,5 +889,92 @@ quantiles = 0.5, 0.90, 0.95, 0.99\n";
     fail_unless(config.quantiles[3] == 0.99);
 
     unlink("/tmp/extended_counters_include_all_by_default_config");
+}
+END_TEST
+
+START_TEST(test_timers_include_count_only)
+{
+    int fh = open("/tmp/extended_counters_include_count_config", O_CREAT|O_RDWR, 0777);
+    char *buf = "[statsite]\n\
+timers_include = COUNT\n";
+    write(fh, buf, strlen(buf));
+    fchmod(fh, 777);
+    close(fh);
+
+    statsite_config config;
+    int res = config_from_filename("/tmp/extended_counters_include_count_config", &config);
+    fail_unless(res == 0);
+
+    // Should get the config
+    fail_unless(config.timers_config.count == true);
+    fail_unless(config.timers_config.mean == false);
+    fail_unless(config.timers_config.stdev == false);
+    fail_unless(config.timers_config.sum == false);
+    fail_unless(config.timers_config.sum_sq == false);
+    fail_unless(config.timers_config.lower == false);
+    fail_unless(config.timers_config.upper == false);
+    fail_unless(config.timers_config.rate == false);
+    fail_unless(config.timers_config.median == false);
+    fail_unless(config.timers_config.sample_rate == false);
+
+    unlink("/tmp/extended_counters_include_count_config");
+}
+END_TEST
+
+START_TEST(test_timers_include_count_rate)
+{
+    int fh = open("/tmp/extended_counters_include_count_config", O_CREAT|O_RDWR, 0777);
+    char *buf = "[statsite]\n\
+timers_include = COUNT,RATE\n";
+    write(fh, buf, strlen(buf));
+    fchmod(fh, 777);
+    close(fh);
+
+    statsite_config config;
+    int res = config_from_filename("/tmp/extended_counters_include_count_config", &config);
+    fail_unless(res == 0);
+
+    // Should get the config
+    fail_unless(config.timers_config.count == true);
+    fail_unless(config.timers_config.mean == false);
+    fail_unless(config.timers_config.stdev == false);
+    fail_unless(config.timers_config.sum == false);
+    fail_unless(config.timers_config.sum_sq == false);
+    fail_unless(config.timers_config.lower == false);
+    fail_unless(config.timers_config.upper == false);
+    fail_unless(config.timers_config.rate == true);
+    fail_unless(config.timers_config.median == false);
+    fail_unless(config.timers_config.sample_rate == false);
+
+    unlink("/tmp/extended_counters_include_count_config");
+}
+END_TEST
+
+START_TEST(test_timers_include_all_selected)
+{
+    int fh = open("/tmp/extended_counters_include_count_config", O_CREAT|O_RDWR, 0777);
+    char *buf = "[statsite]\n\
+timers_include = COUNT,MEAN,STDEV,SUM,SUM_SQ,LOWER,UPPER,RATE,MEDIAN,SAMPLE_RATE\n";
+    write(fh, buf, strlen(buf));
+    fchmod(fh, 777);
+    close(fh);
+
+    statsite_config config;
+    int res = config_from_filename("/tmp/extended_counters_include_count_config", &config);
+    fail_unless(res == 0);
+
+    // Should get the config
+    fail_unless(config.timers_config.count == true);
+    fail_unless(config.timers_config.mean == true);
+    fail_unless(config.timers_config.stdev == true);
+    fail_unless(config.timers_config.sum == true);
+    fail_unless(config.timers_config.sum_sq == true);
+    fail_unless(config.timers_config.lower == true);
+    fail_unless(config.timers_config.upper == true);
+    fail_unless(config.timers_config.rate == true);
+    fail_unless(config.timers_config.median == true);
+    fail_unless(config.timers_config.sample_rate == true);
+
+    unlink("/tmp/extended_counters_include_count_config");
 }
 END_TEST


### PR DESCRIPTION
Inspired by #145, I've created a PR to add a `timers_include` config option to allow you to specify which timer metrics to emit.

As with the `extended_counters_include` option it's backwards compatible. You can additionally specify a whether to emit `median` and `sample_rate`