### PR TITLE
CentOS7 systemd related fixes

### DIFF
--- a/rpm/statsite.service
+++ b/rpm/statsite.service
@@ -3,10 +3,14 @@ Description=statsite stats aggregator
 
 [Service]
 Type=forking
+User=statsite
+Group=statsite
+RuntimeDirectory=/var/run/statsite
 PIDFile=/var/run/statsite/statsite.pid
 ExecStart=/usr/sbin/statsite -f /etc/statsite/statsite.conf
 Restart=on-failure
-User=statsite
+StandardOutput=syslog
+StandardError=syslog
 
 [Install]
 WantedBy=multi-user.target

--- a/rpm/statsite.service
+++ b/rpm/statsite.service
@@ -9,8 +9,6 @@ RuntimeDirectory=/var/run/statsite
 PIDFile=/var/run/statsite/statsite.pid
 ExecStart=/usr/sbin/statsite -f /etc/statsite/statsite.conf
 Restart=on-failure
-StandardOutput=syslog
-StandardError=syslog
 
 [Install]
 WantedBy=multi-user.target

--- a/rpm/statsite.spec
+++ b/rpm/statsite.spec
@@ -11,7 +11,7 @@ Source0:	statsite.tar.gz
 BuildRoot:	%(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 BuildRequires:	scons check-devel %{?el7:systemd} %{?fedora:systemd}
 AutoReqProv:	No
-Requires(pre):  /usr/sbin/useradd, /usr/sbin/groupadd
+Requires(pre):  shadow-utils
 
 %description
 
@@ -19,8 +19,11 @@ Statsite is a metrics aggregation server. Statsite is based heavily on Etsy\'s S
 https://github.com/etsy/statsd, and is wire compatible.
 
 %pre
-/usr/sbin/groupadd -r statsite 2>/dev/null || :
-/usr/sbin/useradd -r -d /var/lib/statsite -s /sbin/nologin statsite -g statsite -c "Statsite user" 2>/dev/null || : 
+getent group %{name} >/dev/null || groupadd -r %{name}
+getent passwd  %{name}  >/dev/null || \
+    useradd -r -g  %{name} -d /var/lib/%{name} -s /sbin/nologin \
+    -c "Statsite user" %{name} 
+exit 0
 
 %prep
 %setup -c %{name}-%{version}
@@ -102,7 +105,7 @@ exit 0
 %if 0%{?fedora}%{?el7}
 %attr(644, root, root) %{_unitdir}/statsite.service
 %dir /etc/tmpfiles.d
-%attr(755, root, root) /etc/tmpfiles.d/statsite.conf
+%attr(644, root, root) /etc/tmpfiles.d/statsite.conf
 %else
 %attr(755, root, root) /etc/init.d/statsite
 %endif

--- a/rpm/statsite.spec
+++ b/rpm/statsite.spec
@@ -12,10 +12,16 @@ BuildRoot:	%(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 BuildRequires:	scons check-devel %{?el7:systemd} %{?fedora:systemd}
 AutoReqProv:	No
 
+Requires(pre): /usr/sbin/useradd, /usr/sbin/groupadd
+
 %description
 
 Statsite is a metrics aggregation server. Statsite is based heavily on Etsy\'s StatsD
 https://github.com/etsy/statsd, and is wire compatible.
+
+%pre
+/usr/sbin/groupadd -r statsite 2>/dev/null || :
+/usr/sbin/useradd -r -d /var/lib/statsite -s /sbin/nologin statsite -g statsite -c "Statsite user" 2>/dev/null || : 
 
 %prep
 %setup -c %{name}-%{version}
@@ -28,7 +34,8 @@ mkdir -vp $RPM_BUILD_ROOT/usr/sbin
 mkdir -vp $RPM_BUILD_ROOT/etc/init.d
 mkdir -vp $RPM_BUILD_ROOT/etc/%{name}
 mkdir -vp $RPM_BUILD_ROOT/usr/libexec/%{name}
-mkdir -vp $RPM_BUILD_ROOT/var/run/statsite
+mkdir -vp $RPM_BUILD_ROOT/var/run/%{name}
+mkdir -vp $RPM_BUILD_ROOT/var/lib/%{name}
 
 %if 0%{?fedora}%{?el7}
 mkdir -vp $RPM_BUILD_ROOT/%{_unitdir}
@@ -99,6 +106,7 @@ exit 0
 %dir /usr/libexec/statsite
 %dir /usr/libexec/statsite/sinks
 %attr(755, statsite, statsite) /var/run/statsite
+%attr(755, statsite, statsite) /var/lib/statsite
 %attr(755, root, root) /usr/libexec/statsite/sinks/__init__.py
 %attr(755, root, root) /usr/libexec/statsite/sinks/binary_sink.py
 %attr(755, root, root) /usr/libexec/statsite/sinks/librato.py

--- a/rpm/statsite.spec
+++ b/rpm/statsite.spec
@@ -11,8 +11,7 @@ Source0:	statsite.tar.gz
 BuildRoot:	%(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 BuildRequires:	scons check-devel %{?el7:systemd} %{?fedora:systemd}
 AutoReqProv:	No
-
-Requires(pre): /usr/sbin/useradd, /usr/sbin/groupadd
+Requires(pre):  /usr/sbin/useradd, /usr/sbin/groupadd
 
 %description
 
@@ -33,6 +32,7 @@ make %{?_smp_mflags}
 mkdir -vp $RPM_BUILD_ROOT/usr/sbin
 mkdir -vp $RPM_BUILD_ROOT/etc/init.d
 mkdir -vp $RPM_BUILD_ROOT/etc/%{name}
+mkdir -vp $RPM_BUILD_ROOT/etc/tmpfiles.d
 mkdir -vp $RPM_BUILD_ROOT/usr/libexec/%{name}
 mkdir -vp $RPM_BUILD_ROOT/var/run/%{name}
 mkdir -vp $RPM_BUILD_ROOT/var/lib/%{name}
@@ -40,6 +40,7 @@ mkdir -vp $RPM_BUILD_ROOT/var/lib/%{name}
 %if 0%{?fedora}%{?el7}
 mkdir -vp $RPM_BUILD_ROOT/%{_unitdir}
 install -m 644 rpm/statsite.service $RPM_BUILD_ROOT/%{_unitdir}
+install -m 644 rpm/statsite.tmpfiles.conf $RPM_BUILD_ROOT/etc/tmpfiles.d/statsite.conf
 %else
 install -m 755 rpm/statsite.initscript $RPM_BUILD_ROOT/etc/init.d/statsite
 %endif
@@ -100,6 +101,8 @@ exit 0
 %attr(755, root, root) /usr/sbin/statsite
 %if 0%{?fedora}%{?el7}
 %attr(644, root, root) %{_unitdir}/statsite.service
+%dir /etc/tmpfiles.d
+%attr(755, root, root) /etc/tmpfiles.d/statsite.conf
 %else
 %attr(755, root, root) /etc/init.d/statsite
 %endif

--- a/rpm/statsite.tmpfiles.conf
+++ b/rpm/statsite.tmpfiles.conf
@@ -1,0 +1,1 @@
+d /var/run/statsite 0700 statsite statsite -


### PR DESCRIPTION
Hi. I'd appreciate someone going over this (I'm not an rpm packaging expert). Fixes for statsite user creation and systemd pid dir persistence using /etc/tmpfiles.d/....tested on CentOS7