### PR TITLE
use absolute path in example

### DIFF
--- a/rpm/statsite.conf.example
+++ b/rpm/statsite.conf.example
@@ -5,7 +5,7 @@ log_level=INFO
 flush_interval=10
 timer_eps=0.01
 set_eps=0.02
-stream_cmd=python sinks/graphite.py localhost 2003
+stream_cmd=python /usr/libexec/statsite/sinks/graphite.py localhost 2003
 daemonize=1
 pid_file=/var/run/statsite/statsite.pid
 


### PR DESCRIPTION
Not sure if this is an issue on my system, but statsite is having trouble finding the relative path.