### PR TITLE
Fix +sign used on counters and parsing error 

### DIFF
--- a/integ/test_integ.py
+++ b/integ/test_integ.py
@@ -331,6 +331,18 @@ class TestIntegUDP(object):
         assert out in ("counts.foobar|600.000000|%d\n" % (now),
                        "counts.foobar|600.000000|%d\n" % (now - 1))
 
+    def test_counters_signed(self, servers):
+        "Tests adding kv pairs"
+        _, server, output = servers
+        server.sendall("foobar:+100|c\n")
+        server.sendall("foobar:+200|c\n")
+        server.sendall("foobar:-50|c\n")
+        wait_file(output)
+        now = time.time()
+        out = open(output).read()
+        assert out in ("counts.foobar|250.000000|%d\n" % (now),
+                       "counts.foobar|250.000000|%d\n" % (now - 1))
+
     def test_counters_sample(self, servers):
         "Tests adding kv pairs"
         _, server, output = servers
@@ -342,6 +354,17 @@ class TestIntegUDP(object):
         out = open(output).read()
         assert out in ("counts.foobar|6000.000000|%d\n" % (now),
                        "counts.foobar|6000.000000|%d\n" % (now - 1))
+
+    def test_wrong_protocol_in_a_batch(self, servers):
+        "Tests adding kv pairs"
+        _, server, output = servers
+        server.sendall("foobar10c\nfoobar:10|c\nfoobar:10|c\n")
+        server.sendall("foobar:c\nfoobar:10|c\nfoobar:10|c\n")
+        wait_file(output)
+        now = time.time()
+        out = open(output).read()
+        assert out in ("counts.foobar|40.000000|%d\n" % (now),
+                       "counts.foobar|40.000000|%d\n" % (now - 1))
 
     def test_counters_no_newlines(self, servers):
         "Tests adding counters without a trailing new line"

--- a/src/conn_handler.c
+++ b/src/conn_handler.c
@@ -467,7 +467,7 @@ static int handle_ascii_client_connect(statsite_conn_handler *handle) {
         if (likely(!status)) status |= buffer_after_terminator(val_str, after_len, '|', &type_str, &after_len);
         if (unlikely(status)) {
             syslog(LOG_WARNING, "Failed parse metric! Input: %s", buf);
-            goto ERR_RET;
+            goto END_LOOP;
         }
 
         // Convert the type


### PR DESCRIPTION
This pull request fixes two issues:

1. + sign could not be used with `c` type metrics
2. If a metric has an error while parsing, the rest of the buffer was not consumed. Until another event have been received.