### PR TITLE
Fixes compilation when using musl libc as well as other compiler warnings.

### DIFF
--- a/deps/murmurhash/MurmurHash3.c
+++ b/deps/murmurhash/MurmurHash3.c
@@ -12,7 +12,7 @@
 //-----------------------------------------------------------------------------
 // Platform-specific functions and macros
 
-#define	FORCE_INLINE __attribute__((always_inline))
+#define	FORCE_INLINE inline __attribute__((always_inline))
 
 inline uint64_t rotl64(uint64_t x, int8_t r){
   return (x << r) | (x >> (64 - r));
@@ -124,4 +124,3 @@ void MurmurHash3_x64_128 ( const void * key, const int len,
   ((uint64_t*)out)[0] = h1;
   ((uint64_t*)out)[1] = h2;
 }
-

--- a/src/conn_handler.c
+++ b/src/conn_handler.c
@@ -112,7 +112,7 @@ static int stream_formatter(FILE *pipe, void *data, metric_type type, char *name
         case COUNTER:
             if (GLOBAL_CONFIG->extended_counters) {
                 if (counters_config->count) {
-                    STREAM("%s%s.count|%lld|%lld\n", prefix, name, counter_count(value));
+                    STREAM("%s%s.count|%lu|%lld\n", prefix, name, counter_count(value));
                 }
                 if (counters_config->mean) {
                     STREAM("%s%s.mean|%f|%lld\n", prefix, name, counter_mean(value));
@@ -141,7 +141,7 @@ static int stream_formatter(FILE *pipe, void *data, metric_type type, char *name
             break;
 
         case SET:
-            STREAM("%s%s|%lld|%lld\n", prefix, name, set_size(value));
+            STREAM("%s%s|%lu|%lld\n", prefix, name, set_size(value));
             break;
 
         case TIMER:
@@ -162,7 +162,7 @@ static int stream_formatter(FILE *pipe, void *data, metric_type type, char *name
                 STREAM("%s%s.upper|%f|%lld\n", prefix, name, timer_max(&t->tm));
             }
             if (timers_config->count) {
-                STREAM("%s%s.count|%lld|%lld\n", prefix, name, timer_count(&t->tm));
+                STREAM("%s%s.count|%lu|%lld\n", prefix, name, timer_count(&t->tm));
             }
             if (timers_config->stdev) {
                 STREAM("%s%s.stdev|%f|%lld\n", prefix, name, timer_stddev(&t->tm));

--- a/src/conn_handler.c
+++ b/src/conn_handler.c
@@ -12,6 +12,7 @@
 #include "metrics.h"
 #include "streaming.h"
 #include "conn_handler.h"
+#include <inttypes.h>
 
 /*
  * Binary defines
@@ -112,7 +113,7 @@ static int stream_formatter(FILE *pipe, void *data, metric_type type, char *name
         case COUNTER:
             if (GLOBAL_CONFIG->extended_counters) {
                 if (counters_config->count) {
-                    STREAM("%s%s.count|%lu|%lld\n", prefix, name, counter_count(value));
+                    STREAM("%s%s.count|%"PRIu64"|%lld\n", prefix, name, counter_count(value));
                 }
                 if (counters_config->mean) {
                     STREAM("%s%s.mean|%f|%lld\n", prefix, name, counter_mean(value));
@@ -141,7 +142,7 @@ static int stream_formatter(FILE *pipe, void *data, metric_type type, char *name
             break;
 
         case SET:
-            STREAM("%s%s|%lu|%lld\n", prefix, name, set_size(value));
+            STREAM("%s%s|%"PRIu64"|%lld\n", prefix, name, set_size(value));
             break;
 
         case TIMER:
@@ -162,7 +163,7 @@ static int stream_formatter(FILE *pipe, void *data, metric_type type, char *name
                 STREAM("%s%s.upper|%f|%lld\n", prefix, name, timer_max(&t->tm));
             }
             if (timers_config->count) {
-                STREAM("%s%s.count|%lu|%lld\n", prefix, name, timer_count(&t->tm));
+                STREAM("%s%s.count|%"PRIu64"|%lld\n", prefix, name, timer_count(&t->tm));
             }
             if (timers_config->stdev) {
                 STREAM("%s%s.stdev|%f|%lld\n", prefix, name, timer_stddev(&t->tm));

--- a/src/heap.c
+++ b/src/heap.c
@@ -44,7 +44,7 @@ static int ENTRIES_PER_PAGE = 0;
  * Stores the number of bytes in a single
  * page of memory.
  */
-static int PAGE_SIZE = 0;
+static int MEM_PAGE_SIZE = 0;
 
 // Helper function to map a number of pages into memory
 // Returns NULL on error, otherwise returns a pointer to the
@@ -54,13 +54,13 @@ static void* map_in_pages(int page_count) {
     assert(page_count > 0);
 
     // Call malloc to get the pages
-    void* addr = malloc(page_count*PAGE_SIZE);
+    void* addr = malloc(page_count*MEM_PAGE_SIZE);
 
     if (!addr)
         return NULL;
     else {
         // Clear the memory
-        bzero(addr,page_count*PAGE_SIZE);
+        bzero(addr,page_count*MEM_PAGE_SIZE);
 
         // Return the address
         return addr;
@@ -98,12 +98,12 @@ int compare_int_keys(register void* key1, register void* key2) {
 // Creates a new heap
 void heap_create(heap* h, int initial_size, int (*comp_func)(void*,void*)) {
     // Check if we need to setup our globals
-    if (PAGE_SIZE == 0) {
+    if (MEM_PAGE_SIZE == 0) {
         // Get the page size
-        PAGE_SIZE = getpagesize();
+        MEM_PAGE_SIZE = getpagesize();
 
         // Calculate the max entries
-        ENTRIES_PER_PAGE = PAGE_SIZE / sizeof(heap_entry);
+        ENTRIES_PER_PAGE = MEM_PAGE_SIZE / sizeof(heap_entry);
     }
 
     // Check that initial size is greater than 0, else set it to ENTRIES_PER_PAGE
@@ -185,7 +185,7 @@ void heap_insert(heap *h, void* key, void* value) {
         heap_entry* new_table = map_in_pages(new_size);
 
         // Copy the old entries, copy the entire pages
-        memcpy(new_table, h->table, h->allocated_pages*PAGE_SIZE);
+        memcpy(new_table, h->table, h->allocated_pages*MEM_PAGE_SIZE);
 
         // Cleanup the old table
         map_out_pages(h->table, h->allocated_pages);
@@ -344,7 +344,7 @@ int heap_delmin(heap* h, void** key, void** value) {
         heap_entry* new_table = map_in_pages(new_size);
 
         // Copy the old entries, copy the entire pages
-        memcpy(new_table, h->table, used_pages*PAGE_SIZE);
+        memcpy(new_table, h->table, used_pages*MEM_PAGE_SIZE);
 
         // Cleanup the old table
         map_out_pages(h->table, h->allocated_pages);
@@ -376,5 +376,3 @@ void heap_foreach(heap* h, void (*func)(void*,void*)) {
         func(entry->key, entry->value);
     }
 }
-
-


### PR DESCRIPTION
I tested this on OS X and Alpine. But not on Windows.