### PR TITLE
Add libtool as requirement in Install instruction.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Estimation Algorithm".
 Install
 -------
 
-Download and build from source. This requires `autoconf` and `automake` to be available,
+Download and build from source. This requires `autoconf`, `automake` and `libtool` to be available,
 available usually through a system package manager. Steps:
 
     $ git clone https://github.com/armon/statsite.git


### PR DESCRIPTION
Hello.
I think that package `libtool` must be mentioned as requirement. This package is not installed as dependency of another required packages on Ubuntu. For example, I have installed packages:
```
root@cs29839:~/statsite# dpkg -l build-essential autoconf automake
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name                               Version                Architecture           Description
+++-==================================-======================-======================-==========================================================================
ii  autoconf                           2.69-9                 all                    automatic configure script builder
ii  automake                           1:1.15-4ubuntu1        all                    Tool for generating GNU Standards-compliant Makefiles
ii  build-essential                    12.1ubuntu2            amd64                  Informational list of build-essential packages
```
But `libtool` is not depend from them:
```
root@cs29839:~/statsite# apt-rdepends --state-follow=Installed --state-show=Installed -r libtool
Reading package lists... Done
Building dependency tree       
Reading state information... Done
libtool
```

Thus, `bootstrap.sh` does not call `libtoolize`:
```
root@cs29839:~/statsite# ./bootstrap.sh 
+ mkdir -p m4 ac_config
+ aclocal -I ac_config
+ command -v libtoolize
+ command -v glibtoolize
+ automake --add-missing --copy
configure.ac:21: installing 'ac_config/compile'
configure.ac:23: installing 'ac_config/install-sh'
configure.ac:23: installing 'ac_config/missing'
Makefile.am: installing 'ac_config/depcomp'
+ autoconf
```

And without it `configure` cannot call marco `LT_INIT`:
```
root@cs29839:~/statsite# ./configure 
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether gcc accepts -g... yes
checking for gcc option to accept ISO C89... none needed
checking whether gcc understands -c and -o together... yes
checking how to run the C preprocessor... gcc -E
checking for grep that handles long lines and -e... /bin/grep
checking for egrep... /bin/grep -E
checking for ANSI C header files... yes
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for unistd.h... yes
checking minix/config.h usability... no
checking minix/config.h presence... no
checking for minix/config.h... no
checking whether it is safe to define __EXTENSIONS__... yes
checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... yes
checking for a thread-safe mkdir -p... /bin/mkdir -p
checking for gawk... gawk
checking whether make sets $(MAKE)... yes
checking for style of include used by make... GNU
checking whether make supports nested variables... yes
checking dependency style of gcc... gcc3
checking for clock_gettime in -lrt... yes
checking whether we are using the GNU C compiler... (cached) yes
checking whether gcc accepts -g... (cached) yes
checking for gcc option to accept ISO C89... (cached) none needed
checking whether gcc understands -c and -o together... (cached) yes
checking whether ln -s works... yes
./configure: line 4673: LT_INIT: command not found
checking that generated files are newer than configure... done
configure: creating ./config.status
config.status: creating Makefile
config.status: executing depfiles commands
```

And linker fails with error:
```
gcc -g -std=gnu99 -pthread -D_GNU_SOURCE -DLOG_PERROR=0 -O3 -pthread -lm -lrt -Ideps/inih/ -Ideps/ae/ -Isrc/ -g -O2   -o src/statsite src/hashmap.o src/heap.o src/radix.o src/hll_constants.o src/hll.o src/set.o src/cm_quantile.o src/timer.o src/counter.o src/metrics.o src/streaming.o src/config.o src/networking.o src/conn_handler.o src/statsite.o deps/ae/libae.a deps/inih/libinih.a deps/murmurhash/libmurmur.a 
src/hll.o: In function `hll_init':
/root/statsite/src/hll.c:48: undefined reference to `ceil'
src/hll.o: In function `raw_estimate':
/root/statsite/src/hll.c:148: undefined reference to `pow'
src/hll.o: In function `linear_count':
/root/statsite/src/hll.c:161: undefined reference to `log'
src/hll.o: In function `hll_precision_for_error':
/root/statsite/src/hll.c:267: undefined reference to `log2'
/root/statsite/src/hll.c:268: undefined reference to `ceil'
src/set.o: In function `set_size':
/root/statsite/src/set.c:109: undefined reference to `ceil'
src/cm_quantile.o: In function `cm_cursor_increment':
/root/statsite/src/cm_quantile.c:220: undefined reference to `ceil'
/root/statsite/src/cm_quantile.c:220: undefined reference to `ceil'
src/cm_quantile.o: In function `cm_query':
/root/statsite/src/cm_quantile.c:166: undefined reference to `ceil'
src/cm_quantile.o:/root/statsite/src/cm_quantile.c:169: more undefined references to `ceil' follow
src/timer.o: In function `timer_stddev':
/root/statsite/src/timer.c:99: undefined reference to `sqrt'
src/counter.o: In function `counter_stddev':
/root/statsite/src/counter.c:68: undefined reference to `sqrt'
src/conn_handler.o: In function `str2double':
/root/statsite/src/conn_handler.c:435: undefined reference to `pow'
collect2: error: ld returned 1 exit status
make[1]: *** [src/statsite] Error 1
make[1]: Leaving directory `/root/statsite'
make: *** [all-recursive] Error 1
```

The error occurs on Ubuntu 14.04 and 16.04, because in these OS `ld` runs with [enabled `--as-needed`](https://wiki.ubuntu.com/NattyNarwhal/ToolchainTransition) by default. And therefore linker becomes sensitive to specified library order. Аnd, as you can see from above link command, the order is [incorrect](http://tldp.org/HOWTO/Program-Library-HOWTO/static-libraries.html).

But if `libtool` is installed, linker runs following:
```
/bin/bash ./libtool  --tag=CC   --mode=link gcc -g -std=gnu99 -pthread -D_GNU_SOURCE -DLOG_PERROR=0 -O3 -pthread -lm -lrt -Ideps/inih/ -Ideps/ae/ -Isrc/ -g -O2   -o src/statsite src/hashmap.o src/heap.o src/radix.o src/hll_constants.o src/hll.o src/set.o src/cm_quantile.o src/timer.o src/counter.o src/metrics.o src/streaming.o src/config.o src/networking.o src/conn_handler.o src/statsite.o deps/ae/libae.a deps/inih/libinih.a deps/murmurhash/libmurmur.a 
libtool: link: gcc -g -std=gnu99 -pthread -D_GNU_SOURCE -DLOG_PERROR=0 -O3 -pthread -Ideps/inih/ -Ideps/ae/ -Isrc/ -g -O2 -o src/statsite src/hashmap.o src/heap.o src/radix.o src/hll_constants.o src/hll.o src/set.o src/cm_quantile.o src/timer.o src/counter.o src/metrics.o src/streaming.o src/config.o src/networking.o src/conn_handler.o src/statsite.o  -lm -lrt deps/ae/libae.a deps/inih/libinih.a deps/murmurhash/libmurmur.a -pthread
```

And all completed successfully.