### PR TITLE
Fix RPMBUILDROOT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,18 +49,15 @@ install-sh
 missing
 stamp-h1
 
-ac_config
 autom4te.cache
 
 .dirstamp
+/dist/
+/config.*
 
 #OSX
 .DS_Store
 
-autom4te.cache/requests
-config.guess
-config.sub
-config.log
 
 Makefile.in
 /Makefile

--- a/Makefile.am
+++ b/Makefile.am
@@ -72,6 +72,7 @@ sdist: clean
 	cp -R . /tmp/statsite-@STATSITE_VERSION@
 	tar -zcv --exclude='.git' --exclude='.gitignore' -f statsite-@STATSITE_VERSION@.tar.gz -C /tmp statsite-@STATSITE_VERSION@
 
+RPMBUILDROOT=/tmp/rpm-build
 rpms: sdist build
 	mkdir -vp $(RPMBUILDROOT)
 	cp -v *.tar.gz $(RPMBUILDROOT)

--- a/rpm/statsite.spec
+++ b/rpm/statsite.spec
@@ -48,7 +48,7 @@ install -m 644 rpm/statsite.tmpfiles.conf $RPM_BUILD_ROOT/etc/tmpfiles.d/statsit
 install -m 755 rpm/statsite.initscript $RPM_BUILD_ROOT/etc/init.d/statsite
 %endif
 
-install -m 755 statsite $RPM_BUILD_ROOT/usr/sbin
+install -m 755 src/statsite $RPM_BUILD_ROOT/usr/sbin
 install -m 644 rpm/statsite.conf.example $RPM_BUILD_ROOT/etc/%{name}/statsite.conf
 cp -a sinks $RPM_BUILD_ROOT/usr/libexec/%{name}
 

--- a/rpm/statsite.spec
+++ b/rpm/statsite.spec
@@ -7,7 +7,7 @@ Summary:	A C implementation of statsd.
 Group:		Applications
 License:	See the LICENSE file.
 URL:		https://github.com/armon/statsite
-Source0:	statsite.tar.gz
+Source0:	%{name}-%{version}.tar.gz
 BuildRoot:	%(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 BuildRequires:	scons check-devel %{?el7:systemd} %{?fedora:systemd}
 AutoReqProv:	No
@@ -26,7 +26,7 @@ getent passwd  %{name}  >/dev/null || \
 exit 0
 
 %prep
-%setup -c %{name}-%{version}
+%setup
 
 %build
 make %{?_smp_mflags}


### PR DESCRIPTION
I know very little for automake but I was having issue with RPMBUILDROOT being empty. It ends up doing failing on mkdir -v  (empty value).

Maybe you're setting that value by command line but I guess we should have default?