### PR TITLE
Graphite sinks add "statsite" prefix by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Here is an example configuration file::
     flush_interval = 10
     timer_eps = 0.01
     set_eps = 0.02
-    stream_cmd = python sinks/graphite.py localhost 2003
+    stream_cmd = python sinks/graphite.py localhost 2003 statsite
 
     [histogram_api]
     prefix=api


### PR DESCRIPTION
This was a little confusing as I had disable global_prefix in statsite directly. Also others sink don't seem to add a prefix (Correct me if I'm wrong)

FYI there is an easy workaround I simply added an empty string in the stream_cmd
stream_cmd = python sinks/graphite.py localhost 2003 ''

To maintain compatibility I adjusted README stream_cmd as this could cause a little bit of confusion on users that didn't realize that is happening.
