### PR TITLE
Update hardcoded version to match latest tag

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,11 +1,11 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 
-AC_INIT([Statsite], [0.7.1])
+AC_INIT([Statsite], [0.8.0])
 
 STATSITE_MAJOR_VERSION=0
-STATSITE_MINOR_VERSION=7
-STATSITE_MICRO_VERSION=1
+STATSITE_MINOR_VERSION=8
+STATSITE_MICRO_VERSION=0
 STATSITE_VERSION=$STATSITE_MAJOR_VERSION.$STATSITE_MINOR_VERSION.$STATSITE_MICRO_VERSION
 
 

--- a/rpm/statsite.spec
+++ b/rpm/statsite.spec
@@ -1,7 +1,7 @@
 %global __os_install_post %(echo '%{__os_install_post}' | sed -e 's!/usr/lib[^[:space:]]*/brp-python-bytecompile[[:space:]].*$!!g')
 
 Name:		statsite
-Version:	0.7.1
+Version:	0.8.0
 Release:	1%{?dist}
 Summary:	A C implementation of statsd.
 Group:		Applications


### PR DESCRIPTION
* latest tag is `v0.8.0`
* the code is still set to `0.7.1`. So RPM built from `master` or
  tag `v0.8.0` will still have version set to `0.7.1`