### PR TITLE
Don't use a bare except

### DIFF
--- a/sinks/graphite.py
+++ b/sinks/graphite.py
@@ -57,7 +57,7 @@ class GraphiteStore(object):
         # Serialize writes to the socket
         try:
             self._write_metric(data)
-        except:
+        except Exception:
             self.logger.exception("Failed to write out the metrics!")
 
     def close(self):
@@ -68,7 +68,7 @@ class GraphiteStore(object):
         try:
             if self.sock:
                 self.sock.close()
-        except:
+        except Exception:
             self.logger.warning("Failed to close connection!")
 
     def _create_socket(self):
@@ -76,7 +76,7 @@ class GraphiteStore(object):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
             sock.connect((self.host, self.port))
-        except:
+        except Exception:
             self.logger.error("Failed to connect!")
             sock = None
         return sock

--- a/sinks/influxdb.py
+++ b/sinks/influxdb.py
@@ -164,7 +164,7 @@ class InfluxDBStore(object):
             else:
                 self.logger.info(info)
 
-        except:
+        except Exception:
             self.logger.exception('Failed to send metrics to InfluxDB:', res.status, res.reason)
 
         conn.close()
@@ -215,7 +215,7 @@ class InfluxDBStore(object):
         try:
             res = conn.getresponse()
             self.logger.info("%s, %s" %(res.status, res.reason))
-        except:
+        except Exception:
             self.logger.exception('Failed to send metrics to InfluxDB:', res.status, res.reason)
 
         conn.close()

--- a/sinks/librato.py
+++ b/sinks/librato.py
@@ -296,7 +296,7 @@ class LibratoStore(object):
         try:
             uname = os.uname()
             system = "; ".join([uname[0], uname[4]])
-        except:
+        except Exception:
             system = os.name()
 
         pver = sys.version_info


### PR DESCRIPTION
Using a bare `except:` in python will catch and swallow unintentional exceptions, like `SystemExit` or `KeyboardInterrupt` that will prevent the process from exiting normally. Typically when someone does `except:`, what they really mean is "catch any normal exceptions", which means to use `Exception`.

For reference, the `Exception` hierarchy can be found here: https://docs.python.org/2/library/exceptions.html#exception-hierarchy