### PR TITLE
src/streaming.c: Add busybox support

### DIFF
--- a/src/streaming.c
+++ b/src/streaming.c
@@ -48,7 +48,7 @@ int stream_to_command(metrics *m, void *data, stream_callback cb, char *cmd) {
         close(filedes[1]);
 
         // Try to run the command
-        res = execl("/bin/sh", "streaming", "-c", cmd, NULL);
+        res = execl("/bin/sh", "sh", "-c", cmd, NULL);
         if (res != 0) perror("Failed to execute command!");
 
         // Always exit


### PR DESCRIPTION
On an embedded linux system using Busybox (https://busybox.net/),
/bin/sh (and other simple linux programs) are really just
symlinks to Busybox. Busybox then infers which program it should
run from argv[0]. This commit changes the argv[0] passed to
/bin/sh to be "sh" as opposed to "streaming" which allows Busybox
to properly infer that it needs to launch a shell.